### PR TITLE
SDL_TEXTINPUT event data is NULL terminated

### DIFF
--- a/src/SDL/Raw/Types.hsc
+++ b/src/SDL/Raw/Types.hsc
@@ -480,7 +480,8 @@ instance Storable Event where
       (#const SDL_TEXTINPUT) -> do
         wid <- (#peek SDL_Event, text.windowID) ptr
         text <- peekArray (#const SDL_TEXTINPUTEVENT_TEXT_SIZE) $ (#ptr SDL_Event, text.text) ptr
-        return $! TextInputEvent typ timestamp wid text
+        let upToNull = takeWhile (/= 0) text
+        return $! TextInputEvent typ timestamp wid upToNull
       (#const SDL_MOUSEMOTION) -> do
         wid <- (#peek SDL_Event, motion.windowID) ptr
         which <- (#peek SDL_Event, motion.which) ptr


### PR DESCRIPTION
On OS X, I get the following crash on TextInputEvent events (including a trace of the argument to `ccharStringToText`):

```
[97,0,0,-96,80,-81,-40,-24,127,127,0,0,56,101,-115,118,-1,127,0,0,80,-81,-40,-24,127,127,0,0,-64,0,74,-122]
main: Cannot decode byte '\xa0': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream
```

It looks null terminated, and this patch fixes the crash. I think perhaps a similar change is required in the SDL_TEXTEDITING clause, however I wasn't able to produce one of those events. (I tried using both `SDL.startTextInput rect` and `SDL.Raw.startTextInput` before the event loop).
