### PR TITLE
Fix timer memory leak

### DIFF
--- a/src/SDL/Time.hs
+++ b/src/SDL/Time.hs
@@ -9,7 +9,6 @@ module SDL.Time
     -- * Timer
   , delay
   , TimerCallback
-  , TimerID(..)
   , RetriggerTimer(..)
   , addTimer
   , removeTimer
@@ -20,7 +19,6 @@ import Data.Data (Data)
 import Data.Typeable
 import Data.Word
 import Foreign
-import Foreign.C
 import GHC.Generics (Generic)
 
 import SDL.Exception
@@ -49,21 +47,29 @@ data RetriggerTimer
 
 type TimerCallback = Word32 -> IO RetriggerTimer
 
-newtype TimerID = TimerID CInt
-  deriving (Eq, Show, Typeable)
+newtype TimerRemoval = TimerRemoval {
+    runTimerRemoval :: IO Bool
+  }
 
-addTimer :: MonadIO m => Word32 -> TimerCallback -> m TimerID
-addTimer timeout callback = liftIO $
-  fmap TimerID $ do
-    cb <- Raw.mkTimerCallback $ wrapCb callback
-    throwIf0 "addTimer" "SDL_AddTimer" $ Raw.addTimer timeout cb nullPtr
+addTimer :: MonadIO m => Word32 -> TimerCallback -> m TimerRemoval
+addTimer timeout callback = liftIO $ do
+    cb <- Raw.mkTimerCallback wrappedCb
+    tid <- throwIf0 "addTimer" "SDL_AddTimer" $ Raw.addTimer timeout cb nullPtr
+    return (TimerRemoval $ auxRemove cb tid)
   where
-    wrapCb :: TimerCallback -> Word32 -> Ptr () -> IO Word32
-    wrapCb cb = \w _ -> do
-      next <- cb w
+    wrappedCb :: Word32 -> Ptr () -> IO Word32
+    wrappedCb w _ = do
+      next <- callback w
       return $ case next of
         Cancel       -> 0
         Reschedule n -> n
 
-removeTimer :: MonadIO m => TimerID -> m Bool
-removeTimer (TimerID t) = Raw.removeTimer t
+    auxRemove :: Raw.TimerCallback -> Raw.TimerID -> IO Bool
+    auxRemove cb tid = do
+      isSuccess <- Raw.removeTimer tid
+      if (isSuccess)
+        then freeHaskellFunPtr cb >> return True
+        else return False
+
+removeTimer :: MonadIO m => TimerRemoval -> m Bool
+removeTimer f = liftIO $ runTimerRemoval f

--- a/src/SDL/Time.hs
+++ b/src/SDL/Time.hs
@@ -9,6 +9,7 @@ module SDL.Time
     -- * Timer
   , delay
   , TimerCallback
+  , TimerRemoval
   , RetriggerTimer(..)
   , addTimer
   , removeTimer


### PR DESCRIPTION
This should fix a leaking `FunPtr` from `mkTimerCallback`. In order to hide this from the user, the return type of `addTimer` has changed from `TimerID` to the new type `TimerRemoval`. A quick glance at the C source code of SDL reveals that the timer id is in fact only used for `removeTimer`, so we're not losing information here.

On a sidenote, be aware that SDL still treats the "rescheduling" in its awkward way (remember #19?), meaning that the callback returns either a new interval or 0 to cancel the timer. Internally, SDL does not update the current timer's interval to the newly returned interval, although the documentation states that (well, it can be interpreted in that way). I will add the necessary line to the C code and try to get it merged into SDL (who knows...). Not sure whether the `Reschedule` type should be kept as is if the SDL people do not want to update the timer's interval.