### PR TITLE
Add function to wrap Surface over Ptr Raw.Surface.

### DIFF
--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -53,6 +53,7 @@ module SDL.Video.Renderer
   , surfaceFormat
   , updateWindowSurface
   , queryTexture
+  , pointerToSurface
   , BlendMode(..)
   , Rectangle(..)
   , Surface
@@ -361,6 +362,9 @@ instance Storable a => Storable (Rectangle a) where
 
 newtype Surface = Surface (Ptr Raw.Surface)
   deriving (Eq, Typeable)
+
+pointerToSurface :: Ptr Raw.Surface -> Surface
+pointerToSurface = Surface
 
 newtype Texture = Texture Raw.Texture
   deriving (Eq, Typeable)

--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -53,10 +53,9 @@ module SDL.Video.Renderer
   , surfaceFormat
   , updateWindowSurface
   , queryTexture
-  , pointerToSurface
   , BlendMode(..)
   , Rectangle(..)
-  , Surface
+  , Surface(..)
   , SurfacePixelFormat
   , Texture
   , TextureInfo(..)
@@ -362,9 +361,6 @@ instance Storable a => Storable (Rectangle a) where
 
 newtype Surface = Surface (Ptr Raw.Surface)
   deriving (Eq, Typeable)
-
-pointerToSurface :: Ptr Raw.Surface -> Surface
-pointerToSurface = Surface
 
 newtype Texture = Texture Raw.Texture
   deriving (Eq, Typeable)


### PR DESCRIPTION
I'm making a binding to SDL2_image, and want to be compatible with haskell-game/sdl2.

The `SDL.Video.Renderer` module doesn't export the `Surface` newtype constructor, and I can't find any other means of converting a `Ptr Raw.Surface` to `Surface`, so I added and exported a function `pointerToSurface` which does exactly that.

This works for me. I'm glad to redo it some other way if there are any issues.