### PR TITLE
More window functions

### DIFF
--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -36,6 +36,7 @@ module SDL.Video
   , getWindowPosition
   , setWindowPosition
   , setWindowSize
+  , getWindowTitle
   , setWindowTitle
 
   -- * Renderer Management
@@ -266,6 +267,15 @@ setWindowTitle :: Window -> Text -> IO ()
 setWindowTitle (Window w) title =
   BS.useAsCString (Text.encodeUtf8 title) $
     Raw.setWindowTitle w
+
+-- | Get the title of the window.
+--
+-- If the window has no title, or if there is no such window, then an empty
+-- string is returned.
+getWindowTitle :: Window -> IO Text
+getWindowTitle (Window w) = do
+    cstr <- Raw.getWindowTitle w
+    Text.decodeUtf8 <$> BS.packCString cstr
 
 -- | Get the text from the clipboard.
 --

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -29,6 +29,7 @@ module SDL.Video
   , getWindowBrightness
   , setWindowBrightness
   , setWindowGammaRamp
+  , getWindowGrab
   , setWindowGrab
   , setWindowMode
   , setWindowMaximumSize
@@ -219,6 +220,10 @@ getWindowBrightness (Window w) =
 -- | Set whether the mouse shall be confined to the window.
 setWindowGrab :: Window -> Bool -> IO ()
 setWindowGrab (Window w) = Raw.setWindowGrab w
+
+-- | Get whether the mouse shall be confined to the window.
+getWindowGrab :: Window -> IO Bool
+getWindowGrab (Window w) = Raw.getWindowGrab w
 
 -- | Change between window modes.
 --

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -39,6 +39,8 @@ module SDL.Video
   , setWindowSize
   , getWindowTitle
   , setWindowTitle
+  , getWindowData
+  , setWindowData
 
   -- * Renderer Management
   , createRenderer
@@ -281,6 +283,17 @@ getWindowTitle :: Window -> IO Text
 getWindowTitle (Window w) = do
     cstr <- Raw.getWindowTitle w
     Text.decodeUtf8 <$> BS.packCString cstr
+
+-- | Associate the given pointer to arbitrary user data with the given window
+-- and name. Returns whatever was associated with the given window and name
+-- before.
+setWindowData :: Window -> CString -> Ptr () -> IO (Ptr ())
+setWindowData (Window w) = Raw.setWindowData w
+
+-- | Retrieve the pointer to arbitrary user data associated with the given
+-- window and name.
+getWindowData :: Window -> CString -> IO (Ptr ())
+getWindowData (Window w) = Raw.getWindowData w
 
 -- | Get the text from the clipboard.
 --

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -42,6 +42,8 @@ module SDL.Video
   , getWindowData
   , setWindowData
   , getWindowConfig
+  , getWindowPixelFormat
+  , PixelFormat(..)
 
   -- * Renderer Management
   , createRenderer
@@ -335,6 +337,10 @@ getWindowConfig (Window w) = do
       , windowResizable    = wFlags .&. Raw.SDL_WINDOW_RESIZABLE > 0
       , windowSize         = wSize
     }
+
+-- | Get the pixel format that is used for the given window.
+getWindowPixelFormat :: Window -> IO PixelFormat
+getWindowPixelFormat (Window w) = fromNumber <$> Raw.getWindowPixelFormat w
 
 -- | Get the text from the clipboard.
 --

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -27,6 +27,7 @@ module SDL.Video
   , getWindowMaximumSize
   , getWindowSize
   , setWindowBordered
+  , getWindowBrightness
   , setWindowBrightness
   , setWindowGammaRamp
   , setWindowGrab
@@ -205,6 +206,14 @@ setWindowBrightness :: Window -> Float -> IO ()
 setWindowBrightness (Window w) brightness = do
   throwIfNot0_ "SDL.Video.setWindowBrightness" "SDL_SetWindowBrightness" $
     Raw.setWindowBrightness w $ realToFrac brightness
+
+-- | Get the gamma value for the display that owns the given window.
+--
+-- Returned value is in range [0,1] where 0 means completely dark and 1
+-- corresponds to normal brightness.
+getWindowBrightness :: Window -> IO Float
+getWindowBrightness (Window w) =
+    realToFrac <$> Raw.getWindowBrightness w
 
 -- | Set whether the mouse shall be confined to the window.
 setWindowGrab :: Window -> Bool -> IO ()

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RecordWildCards #-}
 module SDL.Video
   ( module SDL.Video.OpenGL
   , module SDL.Video.Renderer
@@ -34,6 +33,7 @@ module SDL.Video
   , setWindowMode
   , setWindowMaximumSize
   , setWindowMinimumSize
+  , getWindowPosition
   , setWindowPosition
   , setWindowSize
   , setWindowTitle
@@ -238,6 +238,15 @@ setWindowPosition (Window w) pos = case pos of
   Centered -> let u = Raw.SDL_WINDOWPOS_CENTERED in Raw.setWindowPosition w u u
   Wherever -> let u = Raw.SDL_WINDOWPOS_UNDEFINED in Raw.setWindowPosition w u u
   Absolute (P (V2 x y)) -> Raw.setWindowPosition w x y
+
+-- | Get the position of the window.
+getWindowPosition :: Window -> IO (V2 CInt)
+getWindowPosition (Window w) =
+    alloca $ \wPtr ->
+    alloca $ \hPtr -> do
+        Raw.getWindowPosition w wPtr hPtr
+        V2 <$> peek wPtr <*> peek hPtr 
+
 
 -- | Set the size of the window. Values beyond the maximum supported size are
 -- clamped.


### PR DESCRIPTION
Added a number of window-related functions.
* Not sure though about `getWindowConfig`. We're currently not able to return any OpenGL configuration that may have been used during window creation. There are a number of ways to deal with this, like storing that information somewhere, but I'd rather avoid having non-garbage-collected stuff lying around until we manually free it. So far, I've gone for just returning `Nothing` instead of `Maybe ...`. 
* The second thing is the implementation of the `FromNumber` instance of `WindowMode`. SDL mixes enums and bitwise flags on their side, and I guess there's not much that we can do about that. So far, I'm going for the first apparent windowmode with a fallback to `Windowed`.
* Other than that I happened to notice that instead of `MonadIO` we're explicitly encoding the result type as `IO` all over the place. Should a (smallish) ticket be opened for that?