### PR TITLE
RendererConfig breaking change (issue #21)

### DIFF
--- a/examples/lazyfoo/Lesson04.hs
+++ b/examples/lazyfoo/Lesson04.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE PatternSynonyms #-}
 module Lazyfoo.Lesson04 (main) where
 
@@ -49,9 +48,9 @@ main = do
 
           currentSurface =
             fromMaybe oldSurface $ getLast $
-            foldMap (\case SDL.KeyboardEvent{..}
-                             | keyboardEventKeyMotion == SDL.KeyDown ->
-                                 case SDL.keysymKeycode keyboardEventKeysym of
+            foldMap (\case SDL.KeyboardEvent e
+                             | SDL.keyboardEventKeyMotion e == SDL.KeyDown ->
+                                 case SDL.keysymKeycode (SDL.keyboardEventKeysym e) of
                                    SDL.KeycodeUp    -> Last (Just surfaceUp)
                                    SDL.KeycodeDown  -> Last (Just surfaceDown)
                                    SDL.KeycodeRight -> Last (Just surfaceRight)

--- a/examples/lazyfoo/Lesson07.hs
+++ b/examples/lazyfoo/Lesson07.hs
@@ -33,10 +33,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = False
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson08.hs
+++ b/examples/lazyfoo/Lesson08.hs
@@ -33,10 +33,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = False
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson09.hs
+++ b/examples/lazyfoo/Lesson09.hs
@@ -34,10 +34,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = False
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson10.hs
+++ b/examples/lazyfoo/Lesson10.hs
@@ -51,10 +51,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = False
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson11.hs
+++ b/examples/lazyfoo/Lesson11.hs
@@ -53,10 +53,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = False
-         , SDL.rendererSoftware = True
+         { SDL.rendererType = SDL.SoftwareRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = False
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson12.hs
+++ b/examples/lazyfoo/Lesson12.hs
@@ -61,10 +61,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = False
-         , SDL.rendererSoftware = True
+         { SDL.rendererType = SDL.SoftwareRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = False
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson12.hs
+++ b/examples/lazyfoo/Lesson12.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Lazyfoo.Lesson12 (main) where
 
@@ -61,9 +60,9 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererType = SDL.SoftwareRenderer
-         , SDL.rendererTargetTexture = False
-         })
+        { SDL.rendererType = SDL.SoftwareRenderer
+        , SDL.rendererTargetTexture = False
+        })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound
 
@@ -80,10 +79,10 @@ main = do
         let (Any quit, Sum colorAdjustment) =
               foldMap (\case
                          SDL.QuitEvent -> (Any True, mempty)
-                         SDL.KeyboardEvent{..} ->
+                         SDL.KeyboardEvent e ->
                            (\x -> (mempty, x)) $
-                           if | keyboardEventKeyMotion == SDL.KeyDown ->
-                                  let scancode = SDL.keysymScancode keyboardEventKeysym
+                           if | SDL.keyboardEventKeyMotion e == SDL.KeyDown ->
+                                  let scancode = SDL.keysymScancode (SDL.keyboardEventKeysym e)
                                   in if | scancode == SDL.ScancodeQ -> Sum (V3 32 0 0)
                                         | scancode == SDL.ScancodeW -> Sum (V3 0 32 0)
                                         | scancode == SDL.ScancodeE -> Sum (V3 0 0 32)

--- a/examples/lazyfoo/Lesson13.hs
+++ b/examples/lazyfoo/Lesson13.hs
@@ -64,10 +64,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = False
-         , SDL.rendererSoftware = True
+         { SDL.rendererType = SDL.SoftwareRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = False
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson13.hs
+++ b/examples/lazyfoo/Lesson13.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Lazyfoo.Lesson13 (main) where
 
@@ -64,9 +63,9 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererType = SDL.SoftwareRenderer
-         , SDL.rendererTargetTexture = False
-         })
+        { SDL.rendererType = SDL.SoftwareRenderer
+        , SDL.rendererTargetTexture = False
+        })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound
 
@@ -86,10 +85,10 @@ main = do
         let (Any quit, Sum alphaAdjustment) =
               foldMap (\case
                          SDL.QuitEvent -> (Any True, mempty)
-                         SDL.KeyboardEvent{..} ->
+                         SDL.KeyboardEvent e ->
                            (\x -> (mempty, x)) $
-                           if | keyboardEventKeyMotion == SDL.KeyDown ->
-                                  let scancode = SDL.keysymScancode keyboardEventKeysym
+                           if | SDL.keyboardEventKeyMotion e == SDL.KeyDown ->
+                                  let scancode = SDL.keysymScancode (SDL.keyboardEventKeysym e)
                                   in if | scancode == SDL.ScancodeW -> Sum 32
                                         | scancode == SDL.ScancodeS -> Sum (-32)
                                         | otherwise -> mempty

--- a/examples/lazyfoo/Lesson14.hs
+++ b/examples/lazyfoo/Lesson14.hs
@@ -57,10 +57,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = True
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson15.hs
+++ b/examples/lazyfoo/Lesson15.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Lazyfoo.Lesson15 (main) where
 
@@ -68,9 +67,9 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
-         , SDL.rendererTargetTexture = False
-         })
+        { SDL.rendererType = SDL.AcceleratedVSyncRenderer
+        , SDL.rendererTargetTexture = False
+        })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound
 
@@ -87,10 +86,10 @@ main = do
         let (Any quit, Sum phi, Last newFlips) =
               foldMap (\case
                          SDL.QuitEvent -> (Any True, mempty, mempty)
-                         SDL.KeyboardEvent{..} ->
+                         SDL.KeyboardEvent e ->
                            (\(x,y) -> (mempty, x,y)) $
-                           if | keyboardEventKeyMotion == SDL.KeyDown ->
-                                  let scancode = SDL.keysymScancode keyboardEventKeysym
+                           if | SDL.keyboardEventKeyMotion e == SDL.KeyDown ->
+                                  let scancode = SDL.keysymScancode (SDL.keyboardEventKeysym e)
                                   in if | scancode == SDL.ScancodeQ -> (mempty, Last (Just (V2 True False)))
                                         | scancode == SDL.ScancodeW -> (mempty, Last (Just (V2 False False)))
                                         | scancode == SDL.ScancodeE -> (mempty, Last (Just (V2 False True)))

--- a/examples/lazyfoo/Lesson15.hs
+++ b/examples/lazyfoo/Lesson15.hs
@@ -68,10 +68,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = True
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson17.hs
+++ b/examples/lazyfoo/Lesson17.hs
@@ -101,10 +101,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = True
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson17.hs
+++ b/examples/lazyfoo/Lesson17.hs
@@ -60,9 +60,9 @@ handleEvent mousePos e (Button buttonPos _) =
                foldl1 (&&) ((<=) <$> mousePos <*> buttonPos .+^ buttonSize)
       sprite
         | inside = case e of
-                     SDL.MouseButtonEvent{..}
-                       | mouseButtonEventMotion == SDL.MouseButtonDown -> MouseDown
-                       | mouseButtonEventMotion == SDL.MouseButtonUp -> MouseUp
+                     SDL.MouseButtonEvent e
+                       | SDL.mouseButtonEventMotion e == SDL.MouseButtonDown -> MouseDown
+                       | SDL.mouseButtonEventMotion e == SDL.MouseButtonUp -> MouseUp
                        | otherwise -> MouseOver
                      _ -> MouseOver
         | otherwise = MouseOut
@@ -101,9 +101,9 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
-         , SDL.rendererTargetTexture = False
-         })
+        { SDL.rendererType = SDL.AcceleratedVSyncRenderer
+        , SDL.rendererTargetTexture = False
+        })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound
 

--- a/examples/lazyfoo/Lesson18.hs
+++ b/examples/lazyfoo/Lesson18.hs
@@ -64,10 +64,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = True
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson19.hs
+++ b/examples/lazyfoo/Lesson19.hs
@@ -84,9 +84,9 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
-         , SDL.rendererTargetTexture = False
-         })
+        { SDL.rendererType = SDL.AcceleratedVSyncRenderer
+        , SDL.rendererTargetTexture = False
+        })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound
 
@@ -106,21 +106,21 @@ main = do
         let (Any quit, Last newDir) =
               foldMap (\case
                          SDL.QuitEvent -> (Any True, mempty)
-                         SDL.KeyboardEvent{..} ->
-                           if | keyboardEventKeyMotion == SDL.KeyDown ->
-                                  let scancode = SDL.keysymScancode keyboardEventKeysym
+                         SDL.KeyboardEvent e ->
+                           if | SDL.keyboardEventKeyMotion e == SDL.KeyDown ->
+                                  let scancode = SDL.keysymScancode (SDL.keyboardEventKeysym e)
                                   in if | scancode == SDL.ScancodeEscape -> (Any True, mempty)
                                         | otherwise -> mempty
                               | otherwise -> mempty
-                         SDL.JoyAxisEvent{..} ->
-                           if | joyAxisEventWhich == joystickID ->
+                         SDL.JoyAxisEvent e ->
+                           if | SDL.joyAxisEventWhich e == joystickID ->
                                   (\x -> (mempty, Last $ Just x)) $
-                                  case joyAxisEventAxis of
-                                    0 -> if | joyAxisEventValue < -joystickDeadZone -> (-1, yDir')
-                                            | joyAxisEventValue > joystickDeadZone -> (1, yDir')
+                                  case SDL.joyAxisEventAxis e of
+                                    0 -> if | SDL.joyAxisEventValue e < -joystickDeadZone -> (-1, yDir')
+                                            | SDL.joyAxisEventValue e > joystickDeadZone -> (1, yDir')
                                             | otherwise -> (0, yDir')
-                                    1 -> if | joyAxisEventValue < -joystickDeadZone -> (xDir', -1)
-                                            | joyAxisEventValue > joystickDeadZone -> (xDir', 1)
+                                    1 -> if | SDL.joyAxisEventValue e < -joystickDeadZone -> (xDir', -1)
+                                            | SDL.joyAxisEventValue e > joystickDeadZone -> (xDir', 1)
                                             | otherwise -> (xDir', 0)
                                     _ -> (xDir', yDir')
                               | otherwise -> mempty

--- a/examples/lazyfoo/Lesson19.hs
+++ b/examples/lazyfoo/Lesson19.hs
@@ -84,10 +84,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = True
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson20.hs
+++ b/examples/lazyfoo/Lesson20.hs
@@ -76,9 +76,9 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
-         , SDL.rendererTargetTexture = False
-         })
+        { SDL.rendererType = SDL.AcceleratedVSyncRenderer
+        , SDL.rendererTargetTexture = False
+        })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound
 
@@ -99,14 +99,14 @@ main = do
         let (Any quit, Any buttonDown) =
               foldMap (\case
                          SDL.QuitEvent -> (Any True, mempty)
-                         SDL.KeyboardEvent{..} ->
-                           if | keyboardEventKeyMotion == SDL.KeyDown ->
-                                  let scancode = SDL.keysymScancode keyboardEventKeysym
+                         SDL.KeyboardEvent e ->
+                           if | SDL.keyboardEventKeyMotion e == SDL.KeyDown ->
+                                  let scancode = SDL.keysymScancode (SDL.keyboardEventKeysym e)
                                   in if | scancode == SDL.ScancodeEscape -> (Any True, mempty)
                                         | otherwise -> mempty
                               | otherwise -> mempty
-                         SDL.JoyButtonEvent{..} ->
-                           if | joyButtonEventState /= 0 -> (mempty, Any True)
+                         SDL.JoyButtonEvent e ->
+                           if | SDL.joyButtonEventState e /= 0 -> (mempty, Any True)
                               | otherwise -> mempty
                          _ -> mempty) $
               map SDL.eventPayload events

--- a/examples/lazyfoo/Lesson20.hs
+++ b/examples/lazyfoo/Lesson20.hs
@@ -76,10 +76,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = True
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/lazyfoo/Lesson43.hs
+++ b/examples/lazyfoo/Lesson43.hs
@@ -59,10 +59,8 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-         { SDL.rendererAccelerated = True
-         , SDL.rendererSoftware = False
+         { SDL.rendererType = SDL.AcceleratedVSyncRenderer
          , SDL.rendererTargetTexture = False
-         , SDL.rendererPresentVSync = True
          })
 
   SDL.renderDrawColor renderer $= V4 maxBound maxBound maxBound maxBound

--- a/examples/twinklebear/Lesson01.hs
+++ b/examples/twinklebear/Lesson01.hs
@@ -16,9 +16,7 @@ main = do
   let winConfig = SDL.defaultWindow { SDL.windowPosition = SDL.Absolute (P (V2 100 100))
                                     , SDL.windowInitialSize = V2 640 480 }
 
-      rdrConfig = SDL.RendererConfig { SDL.rendererSoftware      = False
-                                     , SDL.rendererAccelerated   = True
-                                     , SDL.rendererPresentVSync  = True
+      rdrConfig = SDL.RendererConfig { SDL.rendererType = SDL.AcceleratedVSyncRenderer
                                      , SDL.rendererTargetTexture = True }
 
   window <- SDL.createWindow "Hello World!" winConfig

--- a/examples/twinklebear/Lesson02.hs
+++ b/examples/twinklebear/Lesson02.hs
@@ -51,7 +51,7 @@ main = do
   SDL.initialize [ SDL.InitEverything ]
 
   let winConfig = SDL.defaultWindow { SDL.windowInitialSize = V2 screenWidth screenHeight }
-      rdrConfig = SDL.defaultRenderer { SDL.rendererAccelerated = True }
+      rdrConfig = SDL.defaultRenderer { SDL.rendererType = SDL.AcceleratedRenderer }
 
   window <- SDL.createWindow "Lesson 2" winConfig
   renderer <- SDL.createRenderer window (-1) rdrConfig

--- a/examples/twinklebear/Lesson04.hs
+++ b/examples/twinklebear/Lesson04.hs
@@ -54,8 +54,8 @@ main = do
 
         quit <- fmap (\ev -> case SDL.eventPayload ev of
             SDL.QuitEvent -> True
-            (SDL.KeyboardEvent _ SDL.KeyDown _ _ _) -> True
-            (SDL.MouseButtonEvent _ SDL.MouseButtonDown _ _ _ _ _) -> True
+            SDL.KeyboardEvent e -> SDL.keyboardEventKeyMotion e ==  SDL.KeyDown
+            SDL.MouseButtonEvent e -> SDL.mouseButtonEventMotion e == SDL.MouseButtonDown
             _ -> False) SDL.waitEvent
 
         unless quit loop

--- a/examples/twinklebear/Lesson04a.hs
+++ b/examples/twinklebear/Lesson04a.hs
@@ -64,9 +64,9 @@ main = do
         let (Any quit, Sum posDelta) =
               foldMap (\case
                 SDL.QuitEvent -> (Any True, mempty)
-                SDL.KeyboardEvent{..} ->
-                  if | keyboardEventKeyMotion == SDL.KeyDown ->
-                         let scancode = SDL.keysymScancode keyboardEventKeysym
+                SDL.KeyboardEvent e ->
+                  if | SDL.keyboardEventKeyMotion e == SDL.KeyDown ->
+                         let scancode = SDL.keysymScancode (SDL.keyboardEventKeysym e)
                          in if | scancode == SDL.ScancodeUp    -> (Any False, Sum (V2    0  (-10)))
                                | scancode == SDL.ScancodeDown  -> (Any False, Sum (V2    0    10 ))
                                | scancode == SDL.ScancodeLeft  -> (Any False, Sum (V2 (-10)    0 ))

--- a/examples/twinklebear/Lesson05.hs
+++ b/examples/twinklebear/Lesson05.hs
@@ -72,9 +72,9 @@ main = do
         let (Any quit, Last newSpriteRect) =
               foldMap (\case
                 SDL.QuitEvent -> (Any True, mempty)
-                SDL.KeyboardEvent{..} ->
-                  if | keyboardEventKeyMotion == SDL.KeyDown ->
-                         let scancode = SDL.keysymScancode keyboardEventKeysym
+                SDL.KeyboardEvent e ->
+                  if | SDL.keyboardEventKeyMotion e == SDL.KeyDown ->
+                         let scancode = SDL.keysymScancode (SDL.keyboardEventKeysym e)
                          in if | scancode == SDL.Scancode1 -> (Any False, Last (Just spriteOne))
                                | scancode == SDL.Scancode2 -> (Any False, Last (Just spriteTwo))
                                | scancode == SDL.Scancode3 -> (Any False, Last (Just spriteThree))

--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -7,12 +7,48 @@
 module SDL.Event
   ( Event(..)
   , EventPayload(..)
+  , WindowShownEventData(..)
+  , WindowHiddenEventData(..)
+  , WindowExposedEventData(..)
+  , WindowMovedEventData(..)
+  , WindowResizedEventData(..)
+  , WindowSizeChangedEventData(..)
+  , WindowMinimizedEventData(..)
+  , WindowMaximizedEventData(..)
+  , WindowRestoredEventData(..)
+  , WindowGainedMouseFocusEventData(..)
+  , WindowLostMouseFocusEventData(..)
+  , WindowGainedKeyboardFocusEventData(..)
+  , WindowLostKeyboardFocusEventData(..)
+  , WindowClosedEventData(..)
+  , KeyboardEventData(..)
+  , TextEditingEventData(..)
+  , TextInputEventData(..)
+  , MouseMotionEventData(..)
+  , MouseButtonEventData(..)
+  , MouseWheelEventData(..)
+  , JoyAxisEventData(..)
+  , JoyBallEventData(..)
+  , JoyHatEventData(..)
+  , JoyButtonEventData(..)
+  , JoyDeviceEventData(..)
+  , ControllerAxisEventData(..)
+  , ControllerButtonEventData(..)
+  , ControllerDeviceEventData(..)
+  , UserEventData(..)
+  , SysWMEventData(..)
+  , TouchFingerEventData(..)
+  , MultiGestureEventData(..)
+  , DollarGestureEventData(..)
+  , DropEventData(..)
+  , ClipboardUpdateEventData(..)
+  , UnknownEventData(..)
   , KeyMotion(..)
   , KeyState(..)
   , MouseButton(..)
   , MouseMotion(..)
-  , WindowID
   , pollEvent
+  , pollEvents
   , mapEvents
   , Raw.pumpEvents
   , waitEvent
@@ -33,17 +69,253 @@ import Linear.Affine (Point(P))
 import SDL.Input.Keyboard
 import SDL.Input.Mouse
 import SDL.Internal.Numbered
-import SDL.Internal.Types (WindowID(WindowID))
+import SDL.Internal.Types (Window(Window))
 
 import qualified Data.ByteString.Char8 as BSC8
 import qualified Data.Text.Encoding as Text
 import qualified SDL.Exception as SDLEx
 import qualified SDL.Raw as Raw
 
+-- | A single SDL event. This event occured at 'eventTimestamp' and carries data under 'eventPayload'.
 data Event = Event
   { eventTimestamp :: Word32
+    -- ^ The time the event occured.
   , eventPayload :: EventPayload
+    -- ^ Data pertaining to this event.
   } deriving (Eq, Ord, Generic, Show, Typeable)
+
+data EventPayload
+  = WindowShownEvent WindowShownEventData
+  | WindowHiddenEvent WindowHiddenEventData
+  | WindowExposedEvent WindowExposedEventData
+  | WindowMovedEvent WindowMovedEventData
+  | WindowResizedEvent WindowResizedEventData
+  | WindowSizeChangedEvent WindowSizeChangedEventData
+  | WindowMinimizedEvent WindowMinimizedEventData
+  | WindowMaximizedEvent WindowMaximizedEventData
+  | WindowRestoredEvent WindowRestoredEventData
+  | WindowGainedMouseFocusEvent WindowGainedMouseFocusEventData
+  | WindowLostMouseFocusEvent WindowLostMouseFocusEventData
+  | WindowGainedKeyboardFocusEvent WindowGainedKeyboardFocusEventData
+  | WindowLostKeyboardFocusEvent WindowLostKeyboardFocusEventData
+  | WindowClosedEvent WindowClosedEventData
+  | KeyboardEvent KeyboardEventData
+  | TextEditingEvent TextEditingEventData
+  | TextInputEvent TextInputEventData
+  | MouseMotionEvent MouseMotionEventData
+  | MouseButtonEvent MouseButtonEventData
+  | MouseWheelEvent MouseWheelEventData
+  | JoyAxisEvent JoyAxisEventData
+  | JoyBallEvent JoyBallEventData
+  | JoyHatEvent JoyHatEventData
+  | JoyButtonEvent JoyButtonEventData
+  | JoyDeviceEvent JoyDeviceEventData
+  | ControllerAxisEvent ControllerAxisEventData
+  | ControllerButtonEvent ControllerButtonEventData
+  | ControllerDeviceEvent ControllerDeviceEventData
+  | QuitEvent
+  | UserEvent UserEventData
+  | SysWMEvent SysWMEventData
+  | TouchFingerEvent TouchFingerEventData
+  | MultiGestureEvent MultiGestureEventData
+  | DollarGestureEvent DollarGestureEventData
+  | DropEvent DropEventData
+  | ClipboardUpdateEvent ClipboardUpdateEventData
+  | UnknownEvent UnknownEventData
+  deriving (Eq, Ord, Generic, Show, Typeable)
+
+data WindowShownEventData =
+  WindowShownEventData {windowShownEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowHiddenEventData =
+  WindowHiddenEventData {windowHiddenEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowExposedEventData =
+  WindowExposedEventData {windowExposedEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowMovedEventData =
+  WindowMovedEventData {windowMovedEventWindow :: Window
+                       ,windowMovedEventPosition :: Point V2 Int32}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowResizedEventData =
+  WindowResizedEventData {windowResizedEventWindow :: Window
+                         ,windowResizedEventSize :: V2 Int32}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowSizeChangedEventData =
+  WindowSizeChangedEventData {windowSizeChangedEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowMinimizedEventData =
+  WindowMinimizedEventData {windowMinimizedEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowMaximizedEventData =
+  WindowMaximizedEventData {windowMaximizedEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowRestoredEventData =
+  WindowRestoredEventData {windowRestoredEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowGainedMouseFocusEventData =
+  WindowGainedMouseFocusEventData {windowGainedMouseFocusEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowLostMouseFocusEventData =
+  WindowLostMouseFocusEventData {windowLostMouseFocusEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowGainedKeyboardFocusEventData =
+  WindowGainedKeyboardFocusEventData {windowGainedKeyboardFocusEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowLostKeyboardFocusEventData =
+  WindowLostKeyboardFocusEventData {windowLostKeyboardFocusEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data WindowClosedEventData =
+  WindowClosedEventData {windowClosedEventWindow :: Window}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data KeyboardEventData =
+  KeyboardEventData {keyboardEventWindow :: Window
+                    ,keyboardEventKeyMotion :: KeyMotion
+                    ,keyboardEventState :: KeyState
+                    ,keyboardEventRepeat :: Bool
+                    ,keyboardEventKeysym :: Keysym}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data TextEditingEventData =
+  TextEditingEventData {textEditingEventWindow :: Window
+                       ,textEditingEventText :: Text
+                       ,textEditingEventStart :: Int32
+                       ,textEditingEventLength :: Int32}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data TextInputEventData =
+  TextInputEventData {textInputEventWindow :: Window
+                     ,textInputEventText :: Text}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data MouseMotionEventData =
+  MouseMotionEventData {mouseMotionEventWindow :: Window
+                       ,mouseMotionEventWhich :: MouseDevice
+                       ,mouseMotionEventState :: [MouseButton]
+                       ,mouseMotionEventPos :: Point V2 Int32
+                       ,mouseMotionEventRelMotion :: V2 Int32}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data MouseButtonEventData =
+  MouseButtonEventData {mouseButtonEventWindow :: Window
+                       ,mouseButtonEventMotion :: MouseMotion
+                       ,mouseButtonEventWhich :: MouseDevice
+                       ,mouseButtonEventButton :: MouseButton
+                       ,mouseButtonEventState :: Word8
+                       ,mouseButtonEventClicks :: Word8
+                       ,mouseButtonEventPos :: Point V2 Int32}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data MouseWheelEventData =
+  MouseWheelEventData {mouseWheelEventWindow :: Window
+                      ,mouseWheelEventWhich :: MouseDevice
+                      ,mouseWheelEventPos :: V2 Int32}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data JoyAxisEventData =
+  JoyAxisEventData {joyAxisEventWhich :: Raw.JoystickID
+                   ,joyAxisEventAxis :: Word8
+                   ,joyAxisEventValue :: Int16}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data JoyBallEventData =
+  JoyBallEventData {joyBallEventWhich :: Raw.JoystickID
+                   ,joyBallEventBall :: Word8
+                   ,joyBallEventRelMotion :: V2 Int16}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data JoyHatEventData =
+  JoyHatEventData {joyHatEventWhich :: Raw.JoystickID
+                  ,joyHatEventHat :: Word8
+                  ,joyHatEventValue :: Word8}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data JoyButtonEventData =
+  JoyButtonEventData {joyButtonEventWhich :: Raw.JoystickID
+                     ,joyButtonEventButton :: Word8
+                     ,joyButtonEventState :: Word8}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data JoyDeviceEventData =
+  JoyDeviceEventData {joyDeviceEventWhich :: Int32}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data ControllerAxisEventData =
+  ControllerAxisEventData {controllerAxisEventWhich :: Raw.JoystickID
+                          ,controllerAxisEventAxis :: Word8
+                          ,controllerAxisEventValue :: Int16}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data ControllerButtonEventData =
+  ControllerButtonEventData {controllerButtonEventWhich :: Raw.JoystickID
+                            ,controllerButtonEventButton :: Word8
+                            ,controllerButtonEventState :: Word8}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data ControllerDeviceEventData =
+  ControllerDeviceEventData {controllerDeviceEventWhich :: Int32}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data UserEventData =
+  UserEventData {userEventWindow :: Window
+                ,userEventCode :: Int32
+                ,userEventData1 :: Ptr ()
+                ,userEventData2 :: Ptr ()}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data SysWMEventData =
+  SysWMEventData {sysWMEventMsg :: Raw.SysWMmsg}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data TouchFingerEventData =
+  TouchFingerEventData {touchFingerEventTouchID :: Raw.TouchID
+                       ,touchFingerEventFingerID :: Raw.FingerID
+                       ,touchFingerEventPos :: Point V2 CFloat
+                       ,touchFingerEventRelMotion :: V2 CFloat
+                       ,touchFingerEventPressure :: CFloat}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data MultiGestureEventData =
+  MultiGestureEventData {multiGestureEventTouchID :: Raw.TouchID
+                        ,multiGestureEventDTheta :: CFloat
+                        ,multiGestureEventDDist :: CFloat
+                        ,multiGestureEventPos :: Point V2 CFloat
+                        ,multiGestureEventNumFingers :: Word16}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data DollarGestureEventData =
+  DollarGestureEventData {dollarGestureEventTouchID :: Raw.TouchID
+                         ,dollarGestureEventGestureID :: Raw.GestureID
+                         ,dollarGestureEventNumFingers :: Word32
+                         ,dollarGestureEventError :: CFloat
+                         ,dollagGestureEventPos :: Point V2 CFloat}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data DropEventData =
+  DropEventData {dropEventFile :: CString}
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data ClipboardUpdateEventData =
+  ClipboardUpdateEventData
+  deriving (Eq,Ord,Generic,Show,Typeable)
+
+data UnknownEventData =
+  UnknownEventData {unknownEventType :: Word32}
+  deriving (Eq,Ord,Generic,Show,Typeable)
 
 data KeyMotion = KeyUp | KeyDown
   deriving (Bounded, Enum, Eq, Ord, Read, Data, Generic, Show, Typeable)
@@ -56,165 +328,6 @@ instance FromNumber KeyState Word8 where
     Raw.SDL_PRESSED -> KeyPressed
     Raw.SDL_RELEASED -> KeyReleased
 
-data EventPayload
-  = WindowShown
-    { windowEventWindowID :: WindowID
-    }
-  | WindowHidden
-    { windowEventWindowID :: WindowID
-    }
-  | WindowExposed
-    { windowEventWindowID :: WindowID
-    }
-  | WindowMoved
-    { windowEventWindowID :: WindowID
-    , windowEventPosition :: Point V2 Int32
-    }
-  | WindowResized
-    { windowEventWindowID :: WindowID
-    , windowEventSize :: V2 Int32
-    }
-  | WindowSizeChanged
-    { windowEventWindowID :: WindowID
-    }
-  | WindowMinimized
-    { windowEventWindowID :: WindowID
-    }
-  | WindowMaximized
-    { windowEventWindowID :: WindowID
-    }
-  | WindowRestored
-    { windowEventWindowID :: WindowID
-    }
-  | WindowGainedMouseFocus
-    { windowEventWindowID :: WindowID
-    }
-  | WindowLostMouseFocus
-    { windowEventWindowID :: WindowID
-    }
-  | WindowGainedKeyboardFocus
-    { windowEventWindowID :: WindowID
-    }
-  | WindowLostKeyboardFocus
-    { windowEventWindowID :: WindowID
-    }
-  | WindowClosed
-    { windowEventWindowID :: WindowID
-    }
-  | KeyboardEvent
-    { keyboardEventWindowID :: WindowID
-    , keyboardEventKeyMotion :: KeyMotion
-    , keyboardEventState :: KeyState
-    , keyboardEventRepeat :: Bool
-    , keyboardEventKeysym :: Keysym
-    }
-  | TextEditingEvent
-    { textEditingEventWindowID :: WindowID
-    , textEditingEventText :: Text
-    , textEditingEventStart :: Int32
-    , textEditingEventLength :: Int32
-    }
-  | TextInputEvent
-    { textInputEventWindowID :: WindowID
-    , textInputEventText :: Text
-    }
-  | MouseMotionEvent
-    { mouseMotionEventWindowID :: WindowID
-    , mouseMotionEventWhich :: MouseDevice
-    , mouseMotionEventState :: [MouseButton]
-    , mouseMotionEventPos :: Point V2 Int32
-    , mouseMotionEventRelMotion :: V2 Int32
-    }
-  | MouseButtonEvent
-    { mouseButtonEventWindowID :: WindowID
-    , mouseButtonEventMotion :: MouseMotion
-    , mouseButtonEventWhich :: MouseDevice
-    , mouseButtonEventButton :: MouseButton
-    , mouseButtonEventState :: Word8
-    , mouseButtonEventClicks :: Word8
-    , mouseButtonEventPos :: Point V2 Int32
-    }
-  | MouseWheelEvent
-    { mouseWheelEventWindowID :: WindowID
-    , mouseWheelEventWhich :: MouseDevice
-    , mouseWheelEventPos :: V2 Int32
-    }
-  | JoyAxisEvent
-    { joyAxisEventWhich :: Raw.JoystickID
-    , joyAxisEventAxis :: Word8
-    , joyAxisEventValue :: Int16
-    }
-  | JoyBallEvent
-    { joyBallEventWhich :: Raw.JoystickID
-    , joyBallEventBall :: Word8
-    , joyBallEventRelMotion :: V2 Int16
-    }
-  | JoyHatEvent
-    { joyHatEventWhich :: Raw.JoystickID
-    , joyHatEventHat :: Word8
-    , joyHatEventValue :: Word8
-    }
-  | JoyButtonEvent
-    { joyButtonEventWhich :: Raw.JoystickID
-    , joyButtonEventButton :: Word8
-    , joyButtonEventState :: Word8
-    }
-  | JoyDeviceEvent
-    { joyDeviceEventWhich :: Int32
-    }
-  | ControllerAxisEvent
-    { controllerAxisEventWhich :: Raw.JoystickID
-    , controllerAxisEventAxis :: Word8
-    , controllerAxisEventValue :: Int16
-    }
-  | ControllerButtonEvent
-    { controllerButtonEventWhich :: Raw.JoystickID
-    , controllerButtonEventButton :: Word8
-    , controllerButtonEventState :: Word8
-    }
-  | ControllerDeviceEvent
-    { controllerDeviceEventWhich :: Int32
-    }
-  | QuitEvent
-  | UserEvent
-    { userEventWindowID :: WindowID
-    , userEventCode :: Int32
-    , userEventData1 :: Ptr ()
-    , userEventData2 :: Ptr ()
-    }
-  | SysWMEvent
-    { sysWMEventMsg :: Raw.SysWMmsg
-    }
-  | TouchFingerEvent
-    { touchFingerEventTouchID :: Raw.TouchID
-    , touchFingerEventFingerID :: Raw.FingerID
-    , touchFingerEventPos :: Point V2 CFloat
-    , touchFingerEventRelMotion :: V2 CFloat
-    , touchFingerEventPressure :: CFloat
-    }
-  | MultiGestureEvent
-    { multiGestureEventTouchID :: Raw.TouchID
-    , multiGestureEventDTheta :: CFloat
-    , multiGestureEventDDist :: CFloat
-    , multiGestureEventPos :: Point V2 CFloat
-    , multiGestureEventNumFingers :: Word16
-    }
-  | DollarGestureEvent
-    { dollarGestureEventTouchID :: Raw.TouchID
-    , dollarGestureEventGestureID :: Raw.GestureID
-    , dollarGestureEventNumFingers :: Word32
-    , dollarGestureEventError :: CFloat
-    , dollagGestureEventPos :: Point V2 CFloat
-    }
-  | DropEvent
-    { dropEventFile :: CString
-    }
-  | ClipboardUpdateEvent
-  | UnknownEvent
-    { unknownEventType :: Word32
-    }
-  deriving (Eq, Ord, Show, Typeable, Generic)
-
 ccharStringToText :: [CChar] -> Text
 ccharStringToText = Text.decodeUtf8 . BSC8.pack . map castCCharToChar
 
@@ -225,74 +338,195 @@ fromRawKeysym (Raw.Keysym scancode keycode modifier) =
         keycode'  = fromNumber keycode
         modifier' = fromNumber (fromIntegral modifier)
 
-convertRaw :: Raw.Event -> Event
-convertRaw (Raw.WindowEvent t ts a b c d) = Event ts $
-  let w' = WindowID a in case b of
-    Raw.SDL_WINDOWEVENT_SHOWN -> WindowShown w'
-    Raw.SDL_WINDOWEVENT_HIDDEN -> WindowHidden w'
-    Raw.SDL_WINDOWEVENT_EXPOSED -> WindowExposed w'
-    Raw.SDL_WINDOWEVENT_MOVED -> WindowMoved w' (P (V2 c d))
-    Raw.SDL_WINDOWEVENT_RESIZED -> WindowResized w' (V2 c d)
-    Raw.SDL_WINDOWEVENT_SIZE_CHANGED -> WindowSizeChanged w'
-    Raw.SDL_WINDOWEVENT_MINIMIZED -> WindowMinimized w'
-    Raw.SDL_WINDOWEVENT_MAXIMIZED -> WindowMaximized w'
-    Raw.SDL_WINDOWEVENT_RESTORED -> WindowRestored w'
-    Raw.SDL_WINDOWEVENT_ENTER -> WindowGainedMouseFocus w'
-    Raw.SDL_WINDOWEVENT_LEAVE -> WindowLostMouseFocus w'
-    Raw.SDL_WINDOWEVENT_FOCUS_GAINED -> WindowGainedKeyboardFocus w'
-    Raw.SDL_WINDOWEVENT_FOCUS_LOST -> WindowLostKeyboardFocus w'
-    Raw.SDL_WINDOWEVENT_CLOSE -> WindowClosed w'
-    _ -> UnknownEvent t
+convertRaw :: Raw.Event -> IO Event
+convertRaw (Raw.WindowEvent t ts a b c d) =
+  do w' <- fmap Window (Raw.getWindowFromID a)
+     return (Event ts
+                   (case b of
+                      Raw.SDL_WINDOWEVENT_SHOWN ->
+                        WindowShownEvent (WindowShownEventData w')
+                      Raw.SDL_WINDOWEVENT_HIDDEN ->
+                        WindowHiddenEvent (WindowHiddenEventData w')
+                      Raw.SDL_WINDOWEVENT_EXPOSED ->
+                        WindowExposedEvent (WindowExposedEventData w')
+                      Raw.SDL_WINDOWEVENT_MOVED ->
+                        WindowMovedEvent
+                          (WindowMovedEventData w'
+                                                (P (V2 c d)))
+                      Raw.SDL_WINDOWEVENT_RESIZED ->
+                        WindowResizedEvent
+                          (WindowResizedEventData w'
+                                                  (V2 c d))
+                      Raw.SDL_WINDOWEVENT_SIZE_CHANGED ->
+                        WindowSizeChangedEvent (WindowSizeChangedEventData w')
+                      Raw.SDL_WINDOWEVENT_MINIMIZED ->
+                        WindowMinimizedEvent (WindowMinimizedEventData w')
+                      Raw.SDL_WINDOWEVENT_MAXIMIZED ->
+                        WindowMaximizedEvent (WindowMaximizedEventData w')
+                      Raw.SDL_WINDOWEVENT_RESTORED ->
+                        WindowRestoredEvent (WindowRestoredEventData w')
+                      Raw.SDL_WINDOWEVENT_ENTER ->
+                        WindowGainedMouseFocusEvent (WindowGainedMouseFocusEventData w')
+                      Raw.SDL_WINDOWEVENT_LEAVE ->
+                        WindowLostMouseFocusEvent (WindowLostMouseFocusEventData w')
+                      Raw.SDL_WINDOWEVENT_FOCUS_GAINED ->
+                        WindowGainedKeyboardFocusEvent (WindowGainedKeyboardFocusEventData w')
+                      Raw.SDL_WINDOWEVENT_FOCUS_LOST ->
+                        WindowLostKeyboardFocusEvent (WindowLostKeyboardFocusEventData w')
+                      Raw.SDL_WINDOWEVENT_CLOSE ->
+                        WindowClosedEvent (WindowClosedEventData w')
+                      _ ->
+                        UnknownEvent (UnknownEventData t)))
 convertRaw (Raw.KeyboardEvent Raw.SDL_KEYDOWN ts a b c d) =
-  Event ts (KeyboardEvent (WindowID a) KeyDown (fromNumber b) (c /= 0) (fromRawKeysym d))
+  do w' <- fmap Window (Raw.getWindowFromID a)
+     return (Event ts
+                   (KeyboardEvent
+                      (KeyboardEventData w'
+                                         KeyDown
+                                         (fromNumber b)
+                                         (c /= 0)
+                                         (fromRawKeysym d))))
 convertRaw (Raw.KeyboardEvent Raw.SDL_KEYUP ts a b c d) =
-  Event ts (KeyboardEvent (WindowID a) KeyUp (fromNumber b) (c /= 0) (fromRawKeysym d))
-convertRaw (Raw.TextEditingEvent _ ts a b c d) = Event ts (TextEditingEvent (WindowID a) (ccharStringToText b) c d)
-convertRaw (Raw.TextInputEvent _ ts a b) = Event ts (TextInputEvent (WindowID a) (ccharStringToText b))
-convertRaw (Raw.MouseMotionEvent _ ts a b c d e f g)
-  = let buttons = catMaybes
-                  [ (Raw.SDL_BUTTON_LMASK `test` c) ButtonLeft
-                  , (Raw.SDL_BUTTON_RMASK `test` c) ButtonRight
-                  , (Raw.SDL_BUTTON_MMASK `test` c) ButtonMiddle
-                  , (Raw.SDL_BUTTON_X1MASK `test` c) ButtonX1
-                  , (Raw.SDL_BUTTON_X2MASK `test` c) ButtonX2 ]
-     in Event ts (MouseMotionEvent (WindowID a) (fromNumber b) buttons (P (V2 d e)) (V2 f g))
-  where mask `test` x = if mask .&. x /= 0 then Just else const Nothing
-convertRaw (Raw.MouseButtonEvent t ts a b c d e f g)
-  = let motion | t == Raw.SDL_MOUSEBUTTONUP = MouseButtonUp
-               | t == Raw.SDL_MOUSEBUTTONDOWN = MouseButtonDown
-        button | c == Raw.SDL_BUTTON_LEFT = ButtonLeft
-               | c == Raw.SDL_BUTTON_MIDDLE = ButtonMiddle
-               | c == Raw.SDL_BUTTON_RIGHT = ButtonRight
-               | c == Raw.SDL_BUTTON_X1 = ButtonX1
-               | c == Raw.SDL_BUTTON_X2 = ButtonX2
-               | otherwise = ButtonExtra $ fromIntegral c
-    in Event ts (MouseButtonEvent (WindowID a) motion (fromNumber b) button d e (P (V2 f g)))
-convertRaw (Raw.MouseWheelEvent _ ts a b c d) = Event ts (MouseWheelEvent (WindowID a) (fromNumber b) (V2 c d))
-convertRaw (Raw.JoyAxisEvent _ ts a b c) = Event ts (JoyAxisEvent a b c)
-convertRaw (Raw.JoyBallEvent _ ts a b c d) = Event ts (JoyBallEvent a b (V2 c d))
-convertRaw (Raw.JoyHatEvent _ ts a b c) = Event ts (JoyHatEvent a b c)
-convertRaw (Raw.JoyButtonEvent _ ts a b c) = Event ts (JoyButtonEvent a b c)
-convertRaw (Raw.JoyDeviceEvent _ ts a) = Event ts (JoyDeviceEvent a)
-convertRaw (Raw.ControllerAxisEvent _ ts a b c) = Event ts (ControllerAxisEvent a b c)
-convertRaw (Raw.ControllerButtonEvent _ ts a b c) = Event ts (ControllerButtonEvent a b c)
-convertRaw (Raw.ControllerDeviceEvent _ ts a) = Event ts (ControllerDeviceEvent a)
-convertRaw (Raw.QuitEvent _ ts) = Event ts QuitEvent
-convertRaw (Raw.UserEvent _ ts a b c d) = Event ts (UserEvent (WindowID a) b c d)
-convertRaw (Raw.SysWMEvent _ ts a) = Event ts (SysWMEvent a)
-convertRaw (Raw.TouchFingerEvent _ ts a b c d e f g) = Event ts (TouchFingerEvent a b (P (V2 c d)) (V2 e f) g)
-convertRaw (Raw.MultiGestureEvent _ ts a b c d e f) = Event ts (MultiGestureEvent a b c (P (V2 d e)) f)
-convertRaw (Raw.DollarGestureEvent _ ts a b c d e f) = Event ts (DollarGestureEvent a b c d (P (V2 e f)))
-convertRaw (Raw.DropEvent _ ts a) = Event ts (DropEvent a)
-convertRaw (Raw.ClipboardUpdateEvent _ ts) = Event ts ClipboardUpdateEvent
-convertRaw (Raw.UnknownEvent t ts) = Event ts (UnknownEvent t)
+  do w' <- fmap Window (Raw.getWindowFromID a)
+     return (Event ts
+                   (KeyboardEvent
+                      (KeyboardEventData w'
+                                         KeyUp
+                                         (fromNumber b)
+                                         (c /= 0)
+                                         (fromRawKeysym d))))
+convertRaw (Raw.TextEditingEvent _ ts a b c d) =
+  do w' <- fmap Window (Raw.getWindowFromID a)
+     return (Event ts
+                   (TextEditingEvent
+                      (TextEditingEventData w'
+                                            (ccharStringToText b)
+                                            c
+                                            d)))
+convertRaw (Raw.TextInputEvent _ ts a b) =
+  do w' <- fmap Window (Raw.getWindowFromID a)
+     return (Event ts
+                   (TextInputEvent
+                      (TextInputEventData w'
+                                          (ccharStringToText b))))
+convertRaw (Raw.MouseMotionEvent _ ts a b c d e f g) =
+  do w' <- fmap Window (Raw.getWindowFromID a)
+     let buttons =
+           catMaybes [(Raw.SDL_BUTTON_LMASK `test` c) ButtonLeft
+                     ,(Raw.SDL_BUTTON_RMASK `test` c) ButtonRight
+                     ,(Raw.SDL_BUTTON_MMASK `test` c) ButtonMiddle
+                     ,(Raw.SDL_BUTTON_X1MASK `test` c) ButtonX1
+                     ,(Raw.SDL_BUTTON_X2MASK `test` c) ButtonX2]
+     return (Event ts
+                   (MouseMotionEvent
+                      (MouseMotionEventData w'
+                                            (fromNumber b)
+                                            buttons
+                                            (P (V2 d e))
+                                            (V2 f g))))
+  where mask `test` x =
+          if mask .&. x /= 0
+             then Just
+             else const Nothing
+convertRaw (Raw.MouseButtonEvent t ts a b c d e f g) =
+  do w' <- fmap Window (Raw.getWindowFromID a)
+     let motion
+           | t == Raw.SDL_MOUSEBUTTONUP = MouseButtonUp
+           | t == Raw.SDL_MOUSEBUTTONDOWN = MouseButtonDown
+         button
+           | c == Raw.SDL_BUTTON_LEFT = ButtonLeft
+           | c == Raw.SDL_BUTTON_MIDDLE = ButtonMiddle
+           | c == Raw.SDL_BUTTON_RIGHT = ButtonRight
+           | c == Raw.SDL_BUTTON_X1 = ButtonX1
+           | c == Raw.SDL_BUTTON_X2 = ButtonX2
+           | otherwise = ButtonExtra $ fromIntegral c
+     return (Event ts
+                   (MouseButtonEvent
+                      (MouseButtonEventData w'
+                                            motion
+                                            (fromNumber b)
+                                            button
+                                            d
+                                            e
+                                            (P (V2 f g)))))
+convertRaw (Raw.MouseWheelEvent _ ts a b c d) =
+  do w' <- fmap Window (Raw.getWindowFromID a)
+     return (Event ts
+                   (MouseWheelEvent
+                      (MouseWheelEventData w'
+                                           (fromNumber b)
+                                           (V2 c d))))
+convertRaw (Raw.JoyAxisEvent _ ts a b c) =
+  return (Event ts (JoyAxisEvent (JoyAxisEventData a b c)))
+convertRaw (Raw.JoyBallEvent _ ts a b c d) =
+  return (Event ts
+                (JoyBallEvent
+                   (JoyBallEventData a
+                                     b
+                                     (V2 c d))))
+convertRaw (Raw.JoyHatEvent _ ts a b c) =
+  return (Event ts (JoyHatEvent (JoyHatEventData a b c)))
+convertRaw (Raw.JoyButtonEvent _ ts a b c) =
+  return (Event ts (JoyButtonEvent (JoyButtonEventData a b c)))
+convertRaw (Raw.JoyDeviceEvent _ ts a) =
+  return (Event ts (JoyDeviceEvent (JoyDeviceEventData a)))
+convertRaw (Raw.ControllerAxisEvent _ ts a b c) =
+  return (Event ts (ControllerAxisEvent (ControllerAxisEventData a b c)))
+convertRaw (Raw.ControllerButtonEvent _ ts a b c) =
+  return (Event ts (ControllerButtonEvent (ControllerButtonEventData a b c)))
+convertRaw (Raw.ControllerDeviceEvent _ ts a) =
+  return (Event ts (ControllerDeviceEvent (ControllerDeviceEventData a)))
+convertRaw (Raw.QuitEvent _ ts) =
+  return (Event ts QuitEvent)
+convertRaw (Raw.UserEvent _ ts a b c d) =
+  do w' <- fmap Window (Raw.getWindowFromID a)
+     return (Event ts (UserEvent (UserEventData w' b c d)))
+convertRaw (Raw.SysWMEvent _ ts a) =
+  return (Event ts (SysWMEvent (SysWMEventData a)))
+convertRaw (Raw.TouchFingerEvent _ ts a b c d e f g) =
+  return (Event ts
+                (TouchFingerEvent
+                   (TouchFingerEventData a
+                                         b
+                                         (P (V2 c d))
+                                         (V2 e f)
+                                         g)))
+convertRaw (Raw.MultiGestureEvent _ ts a b c d e f) =
+  return (Event ts
+                (MultiGestureEvent
+                   (MultiGestureEventData a
+                                          b
+                                          c
+                                          (P (V2 d e))
+                                          f)))
+convertRaw (Raw.DollarGestureEvent _ ts a b c d e f) =
+  return (Event ts
+                (DollarGestureEvent
+                   (DollarGestureEventData a
+                                           b
+                                           c
+                                           d
+                                           (P (V2 e f)))))
+convertRaw (Raw.DropEvent _ ts a) =
+  return (Event ts (DropEvent (DropEventData a)))
+convertRaw (Raw.ClipboardUpdateEvent _ ts) =
+  return (Event ts (ClipboardUpdateEvent ClipboardUpdateEventData))
+convertRaw (Raw.UnknownEvent t ts) =
+  return (Event ts (UnknownEvent (UnknownEventData t)))
 
 pollEvent :: MonadIO m => m (Maybe Event)
 pollEvent = liftIO $ alloca $ \e -> do
   n <- Raw.pollEvent e
   if n == 0
      then return Nothing
-     else Just . convertRaw <$> peek e
+     else fmap Just (peek e >>= convertRaw)
+
+pollEvents :: (Functor m, MonadIO m) => m [Event]
+pollEvents =
+  do e <- pollEvent
+     case e of
+       Nothing -> return []
+       Just e' -> (e' :) <$> pollEvents
 
 mapEvents :: MonadIO m => (Event -> m ()) -> m ()
 mapEvents h = do
@@ -305,11 +539,11 @@ waitEvent :: MonadIO m => m Event
 waitEvent = liftIO $ alloca $ \e -> do
   SDLEx.throwIfNeg_ "SDL.Events.waitEvent" "SDL_WaitEvent" $
     Raw.waitEvent e
-  convertRaw <$> peek e
+  peek e >>= convertRaw
 
 waitEventTimeout :: MonadIO m => CInt -> m (Maybe Event)
 waitEventTimeout timeout = liftIO $ alloca $ \e -> do
   n <- Raw.waitEventTimeout e timeout
   if n == 0
      then return Nothing
-     else Just . convertRaw <$> peek e
+     else fmap Just (peek e >>= convertRaw)

--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -970,8 +970,8 @@ instance FromNumber RendererConfig Word32 where
   fromNumber n = RendererConfig
     { rendererSoftware      = n .&. Raw.SDL_RENDERER_SOFTWARE /= 0
     , rendererAcceleration  = renderAcceleration'
-                              (Raw.SDL_RENDERER_ACCELERATED /= 0)
-                              (Raw.SDL_RENDERER_PRESENTVSYNC /= 0)
+                              (n .&. Raw.SDL_RENDERER_ACCELERATED /= 0)
+                              (n .&. Raw.SDL_RENDERER_PRESENTVSYNC /= 0)
     , rendererTargetTexture = n .&. Raw.SDL_RENDERER_TARGETTEXTURE /= 0
     }
     where

--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -946,7 +946,7 @@ instance ToNumber PixelFormat Word32 where
     UYVY -> Raw.SDL_PIXELFORMAT_UYVY
     YVYU -> Raw.SDL_PIXELFORMAT_YVYU
 
--- | The renderer's acceleration mode
+-- | Renderer acceleration mode
 data RendererAcceleration
   = NotAccelerated
     -- ^ The renderer does not use hardware acceleration

--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -75,7 +75,7 @@ module SDL.Video.Renderer
   , renderViewport
 
   -- * Utilities
-  , RendererAcceleration(..)
+  , RendererType(..)
   , RendererConfig(..)
   , defaultRenderer
   , RendererInfo(..)
@@ -947,20 +947,20 @@ instance ToNumber PixelFormat Word32 where
     YVYU -> Raw.SDL_PIXELFORMAT_YVYU
 
 -- | Renderer acceleration mode
-data RendererAcceleration
-  = NotAccelerated
+data RendererType
+  = UnacceleratedRenderer
     -- ^ The renderer does not use hardware acceleration
-  | Accelerated
+  | AcceleratedRenderer
     -- ^ The renderer uses hardware acceleration and refresh rate is ignored
-  | AcceleratedVSync
+  | AcceleratedVSyncRenderer
     -- ^ The renderer uses hardware acceleration and present is synchronized with the refresh rate
+  | SoftwareRenderer
+    -- ^ The renderer is a software fallback
   deriving (Bounded, Data, Enum, Eq, Generic, Ord, Read, Show, Typeable)
 
 -- | The configuration data used when creating windows.
 data RendererConfig = RendererConfig
-  { rendererSoftware      :: Bool
-    -- ^ The renderer is a software fallback
-  , rendererAcceleration  :: RendererAcceleration
+  { rendererType  :: RendererType
     -- ^ The renderer's acceleration mode
   , rendererTargetTexture :: Bool
     -- ^ The renderer supports rendering to texture
@@ -968,39 +968,39 @@ data RendererConfig = RendererConfig
 
 instance FromNumber RendererConfig Word32 where
   fromNumber n = RendererConfig
-    { rendererSoftware      = n .&. Raw.SDL_RENDERER_SOFTWARE /= 0
-    , rendererAcceleration  = renderAcceleration'
-                              (n .&. Raw.SDL_RENDERER_ACCELERATED /= 0)
-                              (n .&. Raw.SDL_RENDERER_PRESENTVSYNC /= 0)
+    { rendererType          = rendererType'
+                                (n .&. Raw.SDL_RENDERER_SOFTWARE /= 0)
+                                (n .&. Raw.SDL_RENDERER_ACCELERATED /= 0)
+                                (n .&. Raw.SDL_RENDERER_PRESENTVSYNC /= 0)
     , rendererTargetTexture = n .&. Raw.SDL_RENDERER_TARGETTEXTURE /= 0
     }
     where
-      renderAcceleration' a v | a && v    = AcceleratedVSync
-                              | a         = Accelerated
-                              | otherwise = NotAccelerated
+      rendererType' s a v | s         = SoftwareRenderer
+                          | a && v    = AcceleratedVSyncRenderer
+                          | a         = AcceleratedRenderer
+                          | otherwise = UnacceleratedRenderer
 
 instance ToNumber RendererConfig Word32 where
   toNumber config = foldr (.|.) 0
-    [ if rendererSoftware config then Raw.SDL_RENDERER_SOFTWARE else 0
-    , if rendererAcceleration config /= NotAccelerated then Raw.SDL_RENDERER_ACCELERATED else 0
-    , if rendererAcceleration config == AcceleratedVSync then Raw.SDL_RENDERER_PRESENTVSYNC else 0
+    [ if isSoftware then Raw.SDL_RENDERER_SOFTWARE else 0
+    , if not isSoftware then Raw.SDL_RENDERER_ACCELERATED else 0
+    , if rendererType config == AcceleratedVSyncRenderer then Raw.SDL_RENDERER_PRESENTVSYNC  else 0
     , if rendererTargetTexture config then Raw.SDL_RENDERER_TARGETTEXTURE else 0
     ]
+    where
+      isSoftware = rendererType config == SoftwareRenderer
 
 -- | Default options for 'RendererConfig'.
 --
 -- @
 -- 'defaultRenderer' = 'RendererConfig'
---   { 'rendererSoftware'      = False
---   , 'rendererAccelerated'   = True
---   , 'rendererPresentVSync'  = False
+--   { 'rendererType'          = Accelerated
 --   , 'rendererTargetTexture' = False
 --   }
 -- @
 defaultRenderer :: RendererConfig
 defaultRenderer = RendererConfig
-  { rendererSoftware      = False
-  , rendererAcceleration  = Accelerated
+  { rendererType          = AcceleratedRenderer
   , rendererTargetTexture = False
   }
 


### PR DESCRIPTION
Replace three bool fields with a four-way data format to prevent
invalid configurations, per #21.