### PR TITLE
Add new datatypes for SDL2's audio format

### DIFF
--- a/src/SDL/Audio.hs
+++ b/src/SDL/Audio.hs
@@ -259,38 +259,6 @@ decodeAudioFormat audioFormat = AudioFormat numberFormat sampleSize endianess
       where
         mask = shiftL 1 12 -- 0b0001000000000000
 
-
-{-
-
-audioFormatBitSize :: Lens' AudioFormat Word8
-audioFormatFloat :: Lens' AudioFormat Bool
-audioFormatBigEndian :: Lens' AudioFormat Bool
-audioFormatSigned :: Lens' AudioFormat Bool
-
-audioFormatU8 = AudioFormat 0 & audioFormatBitSize .~ 8
-audioFormatS8 = audioFormatU8 & audioFormatSigned .~ True
-
-audioFormatS16LSB = audioFormatS8 & audioFormatBitSize .~ 16
-audioFormatS16MSB = audioFormatS16LSB & audioFormatBigEndian .~ True
-audioFormatS16Sys = _
-audioFormatS16 = audioFormatS16LSB
-audioFormatU16LSB = audioFormatS16LSB & audioFormatSigned .~ False
-audioFormatU16MSB = audioFormatS16MSB & audioFormatSigned .~ False
-audioFormatU16Sys = _
-audioFormatU16 = audioFormatU16LSB
-
-audioFormatS32LSB = audioFormatS16LSB & audioFormatBitSize .~ 32
-audioFormatS32MSB = audioFormatS16MSB & audioFormatBitSize .~ 32
-audioFormatS32Sys = _
-audioFormatS32 = audioFormatS32LSB
-
-audioFormatF32LSB = audioFormatS32LSB & audioFormatFloat .~ True
-audioFormatF32MSB = audioFormatS32MSB & audioFormatFloat .~ True
-audioFormatF32Sys = _
-audioFormatF32 = audioFormatF32LSB
-
--}
-
 data Channels = Mono | Stereo | Quad | FivePointOne
   deriving (Bounded, Data, Enum, Eq, Generic, Ord, Read, Show, Typeable)
 

--- a/src/SDL/Raw/Enum.hsc
+++ b/src/SDL/Raw/Enum.hsc
@@ -16,6 +16,11 @@ module SDL.Raw.Enum (
   pattern SDL_BLENDMODE_ADD,
   pattern SDL_BLENDMODE_MOD,
 
+  -- ** Endian Detetection
+  pattern SDL_BYTEORDER,
+  pattern SDL_LIL_ENDIAN,
+  pattern SDL_BIG_ENDIAN,
+
   -- ** Event Action
   EventAction,
   pattern SDL_ADDEVENT,
@@ -865,8 +870,11 @@ module SDL.Raw.Enum (
 import Data.Int
 import Data.Word
 
+import Foreign.C.Types
+
 type AudioStatus = (#type SDL_AudioStatus)
 type BlendMode = (#type SDL_BlendMode)
+type Endian = CInt
 type EventAction = (#type SDL_eventaction)
 type GameControllerAxis = (#type SDL_GameControllerAxis)
 type GameControllerButton = (#type SDL_GameControllerButton)
@@ -890,6 +898,10 @@ pattern SDL_BLENDMODE_NONE = (#const SDL_BLENDMODE_NONE) :: BlendMode
 pattern SDL_BLENDMODE_BLEND = (#const SDL_BLENDMODE_BLEND) :: BlendMode
 pattern SDL_BLENDMODE_ADD = (#const SDL_BLENDMODE_ADD) :: BlendMode
 pattern SDL_BLENDMODE_MOD = (#const SDL_BLENDMODE_MOD) :: BlendMode
+
+pattern SDL_BYTEORDER = (#const SDL_BYTEORDER) :: Endian
+pattern SDL_LIL_ENDIAN = (#const SDL_LIL_ENDIAN) :: Endian
+pattern SDL_BIG_ENDIAN = (#const SDL_BIG_ENDIAN) :: Endian
 
 pattern SDL_ADDEVENT = (#const SDL_ADDEVENT) :: EventAction
 pattern SDL_PEEKEVENT = (#const SDL_PEEKEVENT) :: EventAction

--- a/src/SDL/Raw/Enum/Internal.hsc
+++ b/src/SDL/Raw/Enum/Internal.hsc
@@ -23,8 +23,11 @@ module SDL.Raw.Enum.Internal (
 import Data.Int
 import Data.Word
 
+import Foreign.C.Types
+
 type AudioStatus = (#type SDL_AudioStatus)
 type BlendMode = (#type SDL_BlendMode)
+type Endian = CInt
 type EventAction = (#type SDL_eventaction)
 type GameControllerAxis = (#type SDL_GameControllerAxis)
 type GameControllerButton = (#type SDL_GameControllerButton)

--- a/src/SDL/Raw/Enum/Pattern.hsc
+++ b/src/SDL/Raw/Enum/Pattern.hsc
@@ -18,6 +18,11 @@ module SDL.Raw.Enum.Pattern (
 	pattern BlendModeAdd,
 	pattern BlendModeMod,
 
+	-- ** Endianess Detection
+	pattern ByteOrder,
+	pattern LittleEndian,
+	pattern BigEndian,
+
 	-- ** Event Action
 	EventAction,
 	pattern EventActionAddEvent,
@@ -868,6 +873,10 @@ pattern BlendModeNone = (#const SDL_BLENDMODE_NONE) :: BlendMode
 pattern BlendModeBlend = (#const SDL_BLENDMODE_BLEND) :: BlendMode
 pattern BlendModeAdd = (#const SDL_BLENDMODE_ADD) :: BlendMode
 pattern BlendModeMod = (#const SDL_BLENDMODE_MOD) :: BlendMode
+
+pattern ByteOrder = (#const SDL_BYTEORDER) :: Endian
+pattern LittleEndian = (#const SDL_LIL_ENDIAN) :: Endian
+pattern BigEndian = (#const SDL_BIG_ENDIAN) :: Endian
 
 pattern EventActionAddEvent = (#const SDL_ADDEVENT) :: EventAction
 pattern EventActionPeekEvent = (#const SDL_PEEKEVENT) :: EventAction


### PR DESCRIPTION
The code for the encoding and decoding of the audio format is derived from
https://wiki.libsdl.org/SDL_AudioFormat

     +----------------------sample is signed if set
     |
     |        +----------sample is bigendian if set
     |        |
     |        |           +--sample is float if set
     |        |           |
     |        |           |  +--sample bit size---+
     |        |           |  |                    |
    15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0

The new introduced haskell datatypes are the following

    data AudioFormat = AudioFormat NumberFormat SampleBitSize Endianess
    data NumberFormat = SignedInteger | UnsignedInteger | Float
    type SampleBitSize = Word8
    data Endianess = LittleEndian | BigEndian | Native

The native endianess detection is not implemented yet. The endianess could be
detected using SDL_endian.h

I hope the use of the new feature `BinaryLiterals` is ok.

Best,
Sven