### PR TITLE
Work around #64 by not using software renderer

### DIFF
--- a/examples/lazyfoo/Lesson13.hs
+++ b/examples/lazyfoo/Lesson13.hs
@@ -63,7 +63,7 @@ main = do
       window
       (-1)
       (SDL.RendererConfig
-        { SDL.rendererType = SDL.SoftwareRenderer
+        { SDL.rendererType = SDL.UnacceleratedRenderer
         , SDL.rendererTargetTexture = False
         })
 


### PR DESCRIPTION
This is an underlying SDL bug that we can do nothing about. A working example beats perfect compliance with the Lazyfoo original.