### PR TITLE
New API for audio callbacks

### DIFF
--- a/examples/AudioExample.hs
+++ b/examples/AudioExample.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE GADTs #-}
+
+module AudioExample where
+
+import Data.IORef
+import Control.Monad
+import Control.Concurrent
+import Data.Int (Int16)
+import SDL
+import Data.Vector.Storable.Mutable as V
+
+sinSamples :: [Int16]
+sinSamples =
+  map (\n ->
+         let t = fromIntegral n / 48000 :: Double
+             freq = 440 * 4
+         in round (fromIntegral (maxBound `div` 2 :: Int16) * sin (t * freq)))
+      [0 ..]
+
+audioCB :: IORef [Int16] -> AudioFormat sampleType -> IOVector sampleType -> IO ()
+audioCB samples format buffer =
+  case format of
+    Signed16BitLEAudio ->
+      do samples' <- readIORef samples
+         let n = V.length buffer
+         sequence_ (zipWith (write buffer)
+                            [0 ..]
+                            (Prelude.take n samples'))
+         writeIORef samples
+                    (Prelude.drop n samples')
+    _ -> error "Unsupported audio format"
+
+main :: IO ()
+main =
+  do initialize [InitEverything]
+     samples <- newIORef sinSamples
+     (device,_) <-
+       openAudioDevice
+         OpenDeviceSpec {SDL.openDeviceFreq =
+                           Mandate 48000
+                        ,SDL.openDeviceFormat =
+                           Mandate Signed16BitNativeAudio
+                        ,SDL.openDeviceChannels =
+                           Mandate Mono
+                        ,SDL.openDeviceSamples = 4096 * 2
+                        ,SDL.openDeviceCallback = audioCB samples
+                        ,SDL.openDeviceUsage = ForPlayback
+                        ,SDL.openDeviceName = Nothing}
+     setAudioDevicePlaybackState device Play
+     forever (threadDelay maxBound)

--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -384,3 +384,14 @@ executable twinklebear-lesson-05
   main-is: Lesson05.hs
   default-language: Haskell2010
   ghc-options: -Wall -main-is TwinkleBear.Lesson05
+
+executable audio-example
+  if flag(examples)
+    build-depends: base >= 4.7 && < 5, lens >= 4.4.0.2 && < 4.13, linear >= 1.10.1.2 && < 1.20, sdl2, vector
+  else
+    buildable: False
+
+  hs-source-dirs: examples
+  main-is: AudioExample.hs
+  default-language: Haskell2010
+  ghc-options: -Wall -main-is AudioExample -threaded

--- a/src/SDL/Raw/Enum.hsc
+++ b/src/SDL/Raw/Enum.hsc
@@ -3,6 +3,23 @@
 module SDL.Raw.Enum (
   -- * Enumerations
 
+  -- ** Audio Format
+  AudioFormat,
+  pattern SDL_AUDIO_S8,
+  pattern SDL_AUDIO_U8,
+  pattern SDL_AUDIO_S16LSB,
+  pattern SDL_AUDIO_S16MSB,
+  pattern SDL_AUDIO_S16SYS,
+  pattern SDL_AUDIO_U16LSB,
+  pattern SDL_AUDIO_U16MSB,
+  pattern SDL_AUDIO_U16SYS,
+  pattern SDL_AUDIO_S32LSB,
+  pattern SDL_AUDIO_S32MSB,
+  pattern SDL_AUDIO_S32SYS,
+  pattern SDL_AUDIO_F32LSB,
+  pattern SDL_AUDIO_F32MSB,
+  pattern SDL_AUDIO_F32SYS,
+
   -- ** Audio Status
   AudioStatus,
   pattern SDL_AUDIO_STOPPED,
@@ -872,6 +889,7 @@ import Data.Word
 
 import Foreign.C.Types
 
+type AudioFormat = (#type SDL_AudioFormat)
 type AudioStatus = (#type SDL_AudioStatus)
 type BlendMode = (#type SDL_BlendMode)
 type Endian = CInt
@@ -889,6 +907,21 @@ type RendererFlip = (#type SDL_RendererFlip)
 type Scancode = (#type SDL_Scancode)
 type SystemCursor = (#type SDL_SystemCursor)
 type ThreadPriority = (#type SDL_ThreadPriority)
+
+pattern SDL_AUDIO_S8 = (#const AUDIO_S8) :: AudioFormat
+pattern SDL_AUDIO_U8 = (#const AUDIO_U8) :: AudioFormat
+pattern SDL_AUDIO_S16LSB = (#const AUDIO_S16LSB) :: AudioFormat
+pattern SDL_AUDIO_S16MSB = (#const AUDIO_S16MSB) :: AudioFormat
+pattern SDL_AUDIO_S16SYS = (#const AUDIO_S16SYS) :: AudioFormat
+pattern SDL_AUDIO_U16LSB = (#const AUDIO_U16LSB) :: AudioFormat
+pattern SDL_AUDIO_U16MSB = (#const AUDIO_U16MSB) :: AudioFormat
+pattern SDL_AUDIO_U16SYS = (#const AUDIO_U16SYS) :: AudioFormat
+pattern SDL_AUDIO_S32LSB = (#const AUDIO_S32LSB) :: AudioFormat
+pattern SDL_AUDIO_S32MSB = (#const AUDIO_S32MSB) :: AudioFormat
+pattern SDL_AUDIO_S32SYS = (#const AUDIO_S32SYS) :: AudioFormat
+pattern SDL_AUDIO_F32LSB = (#const AUDIO_F32LSB) :: AudioFormat
+pattern SDL_AUDIO_F32MSB = (#const AUDIO_F32MSB) :: AudioFormat
+pattern SDL_AUDIO_F32SYS = (#const AUDIO_F32SYS) :: AudioFormat
 
 pattern SDL_AUDIO_STOPPED = (#const SDL_AUDIO_STOPPED) :: AudioStatus
 pattern SDL_AUDIO_PLAYING = (#const SDL_AUDIO_PLAYING) :: AudioStatus

--- a/src/SDL/Raw/Types.hsc
+++ b/src/SDL/Raw/Types.hsc
@@ -119,7 +119,6 @@ foreign import ccall "wrapper"
   mkTimerCallback :: (Word32 -> Ptr () -> IO Word32) -> IO TimerCallback
 
 type AudioDeviceID = Word32
-type AudioFormat = Word16
 type Cond = Ptr ()
 type Cursor = Ptr ()
 type FingerID = Int64


### PR DESCRIPTION
This commit introduces a new API for audio callbacks. There are three
main changes:

1. The 'AudioFormat' type has been reduced to a single enumeration of
   all known formats. This enumeration is a GADT which essentially
   witnesses the Haskell type corresponding to buffer data. For example,
   'Unsigned16BitLEAudio' is for a buffer o16-bit little-endian unsigned
   samples, which is represented as 'Word16' in Haskell.

2. The 'AudioFormat' that the device was opened with is given to the
   audio callback. This callback uses the GADT nature of AudioFormat in
   order to determine the elements of the audio buffer vector.

3. The callback is now given a mutable vector (a
   'Data.Vector.Storable.Mutable.IOVector'), and the user should modify
   this buffer.

This new API gives us an increased amount of type safety when writing to
audio buffers, and avoids internal memory copies by working directly on
the region of memory that SDL has allocated to us.

A new example - 'audio-example' - has been added, demonstrating how this
API works.