### PR TITLE
Updates the example to use a better blue

### DIFF
--- a/src/SDL.hs
+++ b/src/SDL.hs
@@ -104,7 +104,7 @@ In our @appLoop@ we process events and then update the screen accordingly. Here 
 to clear the screen to blue:
 
 @
-  'rendererDrawColor' renderer '$=' V4 0 0 1 1
+  'rendererDrawColor' renderer '$=' V4 0 0 255 255
   'clear' renderer
   'present' renderer
 @
@@ -137,7 +137,7 @@ appLoop renderer = do
             'keysymKeycode' ('keyboardEventKeysym' keyboardEvent) == 'KeycodeQ'
           _ -> False
       qPressed = not (null (filter eventIsQPress events))
-  'rendererDrawColor' renderer '$=' V4 0 0 1 1
+  'rendererDrawColor' renderer '$=' V4 0 0 255 255
   'clear' renderer
   'present' renderer
   unless qPressed (appLoop renderer)


### PR DESCRIPTION
The current example claims the display a blue screen, but uses `V4 0 0 1 1` instead of `V4 0 0 255 255`.

I don't know if there was an API change or if the haskell-game team is big on subtlety, but I'm putting this PR forward for consideration anyhow :)