### PR TITLE
Added initialize' to Init.hs

### DIFF
--- a/src/SDL/Init.hs
+++ b/src/SDL/Init.hs
@@ -29,6 +29,7 @@ import qualified SDL.Raw as Raw
 import Data.Foldable
 #endif
 
+{-# DEPRECATED InitEverything "Instead of initialize [InitEverything], use initializeAll" #-}
 data InitFlag
   = InitTimer
   | InitAudio
@@ -61,9 +62,9 @@ initialize flags =
   throwIfNeg_ "SDL.Init.init" "SDL_Init" $
     Raw.init (foldFlags toNumber flags)
 
--- | Equivalent to @'initialize' ['InitEverything']@.
+-- | Equivalent to @'initialize' ['minBound' .. 'maxBound']@.
 initializeAll :: (Functor m, MonadIO m) => m ()
-initializeAll = initialize [InitEverything]
+initializeAll = initialize [minBound .. maxBound]
 
 -- | Quit and shutdown SDL, freeing any resources that may have been in use.
 -- Do not call any SDL functions after you've called this function, unless

--- a/src/SDL/Init.hs
+++ b/src/SDL/Init.hs
@@ -60,6 +60,10 @@ initialize flags =
   throwIfNeg_ "SDL.Init.init" "SDL_Init" $
     Raw.init (foldFlags toNumber flags)
 
+-- | Equivalent to @'initialize' ['InitEverything']@.
+initialize' :: (Functor m, MonadIO m) => m ()
+initialize' = initialize [InitEverything]
+
 -- | Quit and shutdown SDL, freeing any resources that may have been in use.
 -- Do not call any SDL functions after you've called this function, unless
 -- otherwise documented that you may do so.

--- a/src/SDL/Init.hs
+++ b/src/SDL/Init.hs
@@ -7,6 +7,7 @@
 
 module SDL.Init
   ( initialize
+  , initialize'
   , InitFlag(..)
   , quit
   , version

--- a/src/SDL/Init.hs
+++ b/src/SDL/Init.hs
@@ -7,7 +7,7 @@
 
 module SDL.Init
   ( initialize
-  , initialize'
+  , initializeAll
   , InitFlag(..)
   , quit
   , version
@@ -62,8 +62,8 @@ initialize flags =
     Raw.init (foldFlags toNumber flags)
 
 -- | Equivalent to @'initialize' ['InitEverything']@.
-initialize' :: (Functor m, MonadIO m) => m ()
-initialize' = initialize [InitEverything]
+initializeAll :: (Functor m, MonadIO m) => m ()
+initializeAll = initialize [InitEverything]
 
 -- | Quit and shutdown SDL, freeing any resources that may have been in use.
 -- Do not call any SDL functions after you've called this function, unless


### PR DESCRIPTION
Alias for `initialize [InitEverything]` because a friend of mind thought that looked terribly redundant and it should just be a default parameter. Explained why Haskell doesn't have those, but he has a point; if `SDL_INIT_EVERYTHING` weren't part of SDL itself, I'd argue that it shouldn't exist at all and this should be `initialize [minBound .. maxBound]`.