### PR TITLE
added relative mouse movement function to high level API

### DIFF
--- a/src/SDL/Input/Mouse.hs
+++ b/src/SDL/Input/Mouse.hs
@@ -107,12 +107,8 @@ getRelativeMouseMode = Raw.getRelativeMouseMode
 
 --deprecated
 getMouseLocation :: MonadIO m => m (Point V2 CInt)
-{-# DEPRECATED getMouseLocation "Use getModalMouseLocation, getAbsoluteMouseLocation, or getRelativeMouseLocation instead" #-}
-getMouseLocation = liftIO $
-  alloca $ \x ->
-  alloca $ \y -> do
-    _ <- Raw.getMouseState x y -- We don't deal with button states here
-    P <$> (V2 <$> peek x <*> peek y)
+{-# DEPRECATED getMouseLocation "Use getAbsoluteMouseLocation instead, or getModalMouseLocation to match future behavior." #-}
+getMouseLocation = getAbsoluteMouseLocation
 
 data MouseButton
   = ButtonLeft

--- a/src/SDL/Input/Mouse.hs
+++ b/src/SDL/Input/Mouse.hs
@@ -16,6 +16,7 @@ module SDL.Input.Mouse
 
     -- * Mouse State
   , getMouseLocation
+  , getRelativeMouseLocation
   , getMouseButtons
 
     -- * Warping the Mouse
@@ -134,6 +135,15 @@ getMouseLocation = liftIO $
   alloca $ \y -> do
     _ <- Raw.getMouseState x y -- We don't deal with button states here
     P <$> (V2 <$> peek x <*> peek y)
+
+-- | Retrieve mouse motion
+getRelativeMouseLocation :: MonadIO m => m (Point V2 CInt)
+getRelativeMouseLocation = liftIO $
+  alloca $ \x ->
+  alloca $ \y -> do
+    _ <- Raw.getRelativeMouseState x y
+    P <$> (V2 <$> peek x <*> peek y)
+
 
 -- | Retrieve a mapping of which buttons are currently held down.
 getMouseButtons :: MonadIO m => m (MouseButton -> Bool)


### PR DESCRIPTION
It might be good to have this throw some error or warning if relativeMouseMode isn't on, and then also have a warning for when getMouseLocation is called, but relativeMouseMode is on. I'm not sure how that should be handled. 