### PR TITLE
Fix peeking text of TextEditingEvent

### DIFF
--- a/src/SDL/Raw/Types.hsc
+++ b/src/SDL/Raw/Types.hsc
@@ -475,7 +475,8 @@ instance Storable Event where
         text <- peekArray (#const SDL_TEXTEDITINGEVENT_TEXT_SIZE) $ (#ptr SDL_Event, edit.text) ptr
         start <- (#peek SDL_Event, edit.start) ptr
         len <- (#peek SDL_Event, edit.length) ptr
-        return $! TextEditingEvent typ timestamp wid text start len
+        let upToNull = takeWhile (/= 0) text
+        return $! TextEditingEvent typ timestamp wid upToNull start len
       (#const SDL_TEXTINPUT) -> do
         wid <- (#peek SDL_Event, text.windowID) ptr
         text <- peekArray (#const SDL_TEXTINPUTEVENT_TEXT_SIZE) $ (#ptr SDL_Event, text.text) ptr


### PR DESCRIPTION
My program using 'TextInput (IME)' crashed.
This message below was output.
```
Cannot decode byte '\xa0': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream exit status 1
```

This crash occured when ...
1. I typed a Japanese character.
2. SDL_TEXTEDITING.text data is unmarshaled. (This is utf-8 text. And, it is null-terminated.)
3. Try to decode this utf-8 text, however it contains unintended characters after a null character.

I found the fix of same type for SDL_TEXTINPUT.text data. It was modified a year ago.
So, I fixed in the same way as that.

After that, I checked my program, and it worked as expected.