### PR TITLE
added glGetDrawableSize to SDL.Video.OpenGL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 dist
 dist-*
 cabal-dev
+.stack-work/
+.sosrc
+*.sw[a-z]
+dist/
+*.hi
 *.o
 *.hi
 *.chi

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -288,7 +288,6 @@ getWindowAbsolutePosition (Window w) =
         Raw.getWindowPosition w wPtr hPtr
         V2 <$> peek wPtr <*> peek hPtr
 
-
 -- | Get or set the size of a window's client area. Values beyond the maximum supported size are clamped.
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.


### PR DESCRIPTION
To properly use glViewport on retina macs I needed to expose glGetDrawableSize.