### PR TITLE
Replace deprecated InitEverything with initializeAll

### DIFF
--- a/src/SDL.hs
+++ b/src/SDL.hs
@@ -58,7 +58,7 @@ import "SDL"
 
 main :: IO ()
 main = do
-  'initialize' ['InitEverything']
+  'initializeAll'
 @
 
 Next, you can create a 'Window' by using 'createWindow'
@@ -128,7 +128,7 @@ import "Control.Monad" (unless)
 
 main :: IO ()
 main = do
-  'initialize' ['InitEverything']
+  'initializeAll'
   window <- 'createWindow' "My SDL Application" 'defaultWindow'
   renderer <- 'createRenderer' window (-1) 'defaultRenderer'
   appLoop renderer


### PR DESCRIPTION
When attempting to use the example code from `SDL.hs` I noticed some of the code uses deprecated constructors (`InitEverything`). This PR replaces them with the preferred `initializeAll` function.