### PR TITLE
Replace "not $ null $ filter" with "any"

### DIFF
--- a/src/SDL.hs
+++ b/src/SDL.hs
@@ -142,7 +142,7 @@ appLoop renderer = do
             'keyboardEventKeyMotion' keyboardEvent == 'Pressed' &&
             'keysymKeycode' ('keyboardEventKeysym' keyboardEvent) == 'KeycodeQ'
           _ -> False
-      qPressed = not (null (filter eventIsQPress events))
+      qPressed = any eventIsQPress events
   'rendererDrawColor' renderer '$=' V4 0 0 255 255
   'clear' renderer
   'present' renderer


### PR DESCRIPTION
When trying the examples in `SDL.hs`, hlint was complaining that `not (null (filter ...))` could be replaced with `any`. This is shorter, and in my opinion, clearer.