### PR TITLE
Transformer upper bound update

### DIFF
--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -113,7 +113,7 @@ library
     linear >= 1.10.1.2 && < 1.21,
     StateVar >= 1.1.0.0 && < 1.2,
     text >= 1.1.0.0 && < 1.3,
-    transformers >= 0.2 && < 0.5,
+    transformers >= 0.2 && < 0.5.3.0,
     vector >= 0.10.9.0 && < 0.12
 
   default-language:


### PR DESCRIPTION
Bumping transformer bounds for the latest hackage without going crazy loose. This allows using stack with resolvers based on GHC 8.0.1. It also fixes #115.