### PR TITLE
Fixed GHC 8.0.1 warnings

### DIFF
--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -684,7 +684,7 @@ pollEvent = liftIO $ alloca $ \e -> do
      else fmap Just (peek e >>= convertRaw)
 
 -- | Clear the event queue by polling for all pending events.
-pollEvents :: (Functor m, MonadIO m) => m [Event]
+pollEvents :: MonadIO m => m [Event]
 pollEvents =
   do e <- pollEvent
      case e of

--- a/src/SDL/Haptic.hs
+++ b/src/SDL/Haptic.hs
@@ -159,7 +159,7 @@ uploadEffect (HapticDevice h _ _) effect =
                                     "SDL_HapticNewEffect"
                                     (Raw.hapticNewEffect h ptr)))
 
-runEffect :: (Functor m, MonadIO m) => HapticDevice -> EffectId -> Word32 -> m ()
+runEffect :: MonadIO m => HapticDevice -> EffectId -> Word32 -> m ()
 runEffect (HapticDevice h _ _) (EffectId e) x =
   SDLEx.throwIfNeg_ "SDL.Haptic.runEffect"
                     "SDL_HapticRunEffect"

--- a/src/SDL/Init.hs
+++ b/src/SDL/Init.hs
@@ -57,13 +57,13 @@ instance ToNumber InitFlag Word32 where
 -- You may call this function again with additional subsystems to initialize.
 --
 -- Throws 'SDLEx.SDLException' if initialization fails.
-initialize :: (Foldable f, Functor m, MonadIO m) => f InitFlag -> m ()
+initialize :: (Foldable f, MonadIO m) => f InitFlag -> m ()
 initialize flags =
   throwIfNeg_ "SDL.Init.init" "SDL_Init" $
     Raw.init (foldFlags toNumber flags)
 
 -- | Equivalent to @'initialize' ['minBound' .. 'maxBound']@.
-initializeAll :: (Functor m, MonadIO m) => m ()
+initializeAll :: MonadIO m => m ()
 initializeAll = initialize [minBound .. maxBound]
 
 -- | Quit and shutdown SDL, freeing any resources that may have been in use.

--- a/src/SDL/Input/Joystick.hs
+++ b/src/SDL/Input/Joystick.hs
@@ -70,7 +70,7 @@ availableJoysticks = liftIO $ do
 -- | Open a joystick so that you can start receiving events from interaction with this joystick.
 --
 -- See @<https://wiki.libsdl.org/SDL_JoystickOpen SDL_JoystickOpen>@ for C documentation.
-openJoystick :: (Functor m,MonadIO m)
+openJoystick :: MonadIO m
              => JoystickDevice -- ^ The device to open. Use 'availableJoysticks' to find 'JoystickDevices's
              -> m Joystick
 openJoystick (JoystickDevice _ x) =
@@ -96,7 +96,7 @@ getJoystickID (Joystick j) =
 -- | Determine if a given button is currently held.
 --
 -- See @<https://wiki.libsdl.org/SDL_JoystickGetButton SDL_JoystickGetButton>@ for C documentation.
-buttonPressed :: (Functor m,MonadIO m)
+buttonPressed :: MonadIO m
               => Joystick
               -> CInt -- ^ The index of the button. You can use 'numButtons' to determine how many buttons a given joystick has.
               -> m Bool

--- a/src/SDL/Input/Keyboard.hs
+++ b/src/SDL/Input/Keyboard.hs
@@ -57,7 +57,7 @@ import Control.Applicative
 -- | Get the current key modifier state for the keyboard. The key modifier state is a mask special keys that are held down.
 --
 -- See @<https://wiki.libsdl.org/SDL_GetModState SDL_GetModState>@ for C documentation.
-getModState :: (Functor m, MonadIO m) => m KeyModifier
+getModState :: MonadIO m => m KeyModifier
 getModState = fromNumber <$> Raw.getModState
 
 -- | Information about which keys are currently held down. Use 'getModState' to generate this information.

--- a/src/SDL/Input/Keyboard/Codes.hs
+++ b/src/SDL/Input/Keyboard/Codes.hs
@@ -516,246 +516,487 @@ import qualified SDL.Raw.Enum as Raw
 newtype Scancode = Scancode { unwrapScancode :: Word32 }
   deriving (Bounded, Data, Eq, Ord, Read, Generic, Show, Typeable)
 
+pattern ScancodeUnknown :: Scancode
 pattern ScancodeUnknown = Scancode Raw.SDL_SCANCODE_UNKNOWN
+pattern ScancodeA :: Scancode
 pattern ScancodeA = Scancode Raw.SDL_SCANCODE_A
+pattern ScancodeB :: Scancode
 pattern ScancodeB = Scancode Raw.SDL_SCANCODE_B
+pattern ScancodeC :: Scancode
 pattern ScancodeC = Scancode Raw.SDL_SCANCODE_C
+pattern ScancodeD :: Scancode
 pattern ScancodeD = Scancode Raw.SDL_SCANCODE_D
+pattern ScancodeE :: Scancode
 pattern ScancodeE = Scancode Raw.SDL_SCANCODE_E
+pattern ScancodeF :: Scancode
 pattern ScancodeF = Scancode Raw.SDL_SCANCODE_F
+pattern ScancodeG :: Scancode
 pattern ScancodeG = Scancode Raw.SDL_SCANCODE_G
+pattern ScancodeH :: Scancode
 pattern ScancodeH = Scancode Raw.SDL_SCANCODE_H
+pattern ScancodeI :: Scancode
 pattern ScancodeI = Scancode Raw.SDL_SCANCODE_I
+pattern ScancodeJ :: Scancode
 pattern ScancodeJ = Scancode Raw.SDL_SCANCODE_J
+pattern ScancodeK :: Scancode
 pattern ScancodeK = Scancode Raw.SDL_SCANCODE_K
+pattern ScancodeL :: Scancode
 pattern ScancodeL = Scancode Raw.SDL_SCANCODE_L
+pattern ScancodeM :: Scancode
 pattern ScancodeM = Scancode Raw.SDL_SCANCODE_M
+pattern ScancodeN :: Scancode
 pattern ScancodeN = Scancode Raw.SDL_SCANCODE_N
+pattern ScancodeO :: Scancode
 pattern ScancodeO = Scancode Raw.SDL_SCANCODE_O
+pattern ScancodeP :: Scancode
 pattern ScancodeP = Scancode Raw.SDL_SCANCODE_P
+pattern ScancodeQ :: Scancode
 pattern ScancodeQ = Scancode Raw.SDL_SCANCODE_Q
+pattern ScancodeR :: Scancode
 pattern ScancodeR = Scancode Raw.SDL_SCANCODE_R
+pattern ScancodeS :: Scancode
 pattern ScancodeS = Scancode Raw.SDL_SCANCODE_S
+pattern ScancodeT :: Scancode
 pattern ScancodeT = Scancode Raw.SDL_SCANCODE_T
+pattern ScancodeU :: Scancode
 pattern ScancodeU = Scancode Raw.SDL_SCANCODE_U
+pattern ScancodeV :: Scancode
 pattern ScancodeV = Scancode Raw.SDL_SCANCODE_V
+pattern ScancodeW :: Scancode
 pattern ScancodeW = Scancode Raw.SDL_SCANCODE_W
+pattern ScancodeX :: Scancode
 pattern ScancodeX = Scancode Raw.SDL_SCANCODE_X
+pattern ScancodeY :: Scancode
 pattern ScancodeY = Scancode Raw.SDL_SCANCODE_Y
+pattern ScancodeZ :: Scancode
 pattern ScancodeZ = Scancode Raw.SDL_SCANCODE_Z
+pattern Scancode1 :: Scancode
 pattern Scancode1 = Scancode Raw.SDL_SCANCODE_1
+pattern Scancode2 :: Scancode
 pattern Scancode2 = Scancode Raw.SDL_SCANCODE_2
+pattern Scancode3 :: Scancode
 pattern Scancode3 = Scancode Raw.SDL_SCANCODE_3
+pattern Scancode4 :: Scancode
 pattern Scancode4 = Scancode Raw.SDL_SCANCODE_4
+pattern Scancode5 :: Scancode
 pattern Scancode5 = Scancode Raw.SDL_SCANCODE_5
+pattern Scancode6 :: Scancode
 pattern Scancode6 = Scancode Raw.SDL_SCANCODE_6
+pattern Scancode7 :: Scancode
 pattern Scancode7 = Scancode Raw.SDL_SCANCODE_7
+pattern Scancode8 :: Scancode
 pattern Scancode8 = Scancode Raw.SDL_SCANCODE_8
+pattern Scancode9 :: Scancode
 pattern Scancode9 = Scancode Raw.SDL_SCANCODE_9
+pattern Scancode0 :: Scancode
 pattern Scancode0 = Scancode Raw.SDL_SCANCODE_0
+pattern ScancodeReturn :: Scancode
 pattern ScancodeReturn = Scancode Raw.SDL_SCANCODE_RETURN
+pattern ScancodeEscape :: Scancode
 pattern ScancodeEscape = Scancode Raw.SDL_SCANCODE_ESCAPE
+pattern ScancodeBackspace :: Scancode
 pattern ScancodeBackspace = Scancode Raw.SDL_SCANCODE_BACKSPACE
+pattern ScancodeTab :: Scancode
 pattern ScancodeTab = Scancode Raw.SDL_SCANCODE_TAB
+pattern ScancodeSpace :: Scancode
 pattern ScancodeSpace = Scancode Raw.SDL_SCANCODE_SPACE
+pattern ScancodeMinus :: Scancode
 pattern ScancodeMinus = Scancode Raw.SDL_SCANCODE_MINUS
+pattern ScancodeEquals :: Scancode
 pattern ScancodeEquals = Scancode Raw.SDL_SCANCODE_EQUALS
+pattern ScancodeLeftBracket :: Scancode
 pattern ScancodeLeftBracket = Scancode Raw.SDL_SCANCODE_LEFTBRACKET
+pattern ScancodeRightBracket :: Scancode
 pattern ScancodeRightBracket = Scancode Raw.SDL_SCANCODE_RIGHTBRACKET
+pattern ScancodeBackslash :: Scancode
 pattern ScancodeBackslash = Scancode Raw.SDL_SCANCODE_BACKSLASH
+pattern ScancodeNonUSHash :: Scancode
 pattern ScancodeNonUSHash = Scancode Raw.SDL_SCANCODE_NONUSHASH
+pattern ScancodeSemicolon :: Scancode
 pattern ScancodeSemicolon = Scancode Raw.SDL_SCANCODE_SEMICOLON
+pattern ScancodeApostrophe :: Scancode
 pattern ScancodeApostrophe = Scancode Raw.SDL_SCANCODE_APOSTROPHE
+pattern ScancodeGrave :: Scancode
 pattern ScancodeGrave = Scancode Raw.SDL_SCANCODE_GRAVE
+pattern ScancodeComma :: Scancode
 pattern ScancodeComma = Scancode Raw.SDL_SCANCODE_COMMA
+pattern ScancodePeriod :: Scancode
 pattern ScancodePeriod = Scancode Raw.SDL_SCANCODE_PERIOD
+pattern ScancodeSlash :: Scancode
 pattern ScancodeSlash = Scancode Raw.SDL_SCANCODE_SLASH
+pattern ScancodeCapsLock :: Scancode
 pattern ScancodeCapsLock = Scancode Raw.SDL_SCANCODE_CAPSLOCK
+pattern ScancodeF1 :: Scancode
 pattern ScancodeF1 = Scancode Raw.SDL_SCANCODE_F1
+pattern ScancodeF2 :: Scancode
 pattern ScancodeF2 = Scancode Raw.SDL_SCANCODE_F2
+pattern ScancodeF3 :: Scancode
 pattern ScancodeF3 = Scancode Raw.SDL_SCANCODE_F3
+pattern ScancodeF4 :: Scancode
 pattern ScancodeF4 = Scancode Raw.SDL_SCANCODE_F4
+pattern ScancodeF5 :: Scancode
 pattern ScancodeF5 = Scancode Raw.SDL_SCANCODE_F5
+pattern ScancodeF6 :: Scancode
 pattern ScancodeF6 = Scancode Raw.SDL_SCANCODE_F6
+pattern ScancodeF7 :: Scancode
 pattern ScancodeF7 = Scancode Raw.SDL_SCANCODE_F7
+pattern ScancodeF8 :: Scancode
 pattern ScancodeF8 = Scancode Raw.SDL_SCANCODE_F8
+pattern ScancodeF9 :: Scancode
 pattern ScancodeF9 = Scancode Raw.SDL_SCANCODE_F9
+pattern ScancodeF10 :: Scancode
 pattern ScancodeF10 = Scancode Raw.SDL_SCANCODE_F10
+pattern ScancodeF11 :: Scancode
 pattern ScancodeF11 = Scancode Raw.SDL_SCANCODE_F11
+pattern ScancodeF12 :: Scancode
 pattern ScancodeF12 = Scancode Raw.SDL_SCANCODE_F12
+pattern ScancodePrintScreen :: Scancode
 pattern ScancodePrintScreen = Scancode Raw.SDL_SCANCODE_PRINTSCREEN
+pattern ScancodeScrollLock :: Scancode
 pattern ScancodeScrollLock = Scancode Raw.SDL_SCANCODE_SCROLLLOCK
+pattern ScancodePause :: Scancode
 pattern ScancodePause = Scancode Raw.SDL_SCANCODE_PAUSE
+pattern ScancodeInsert :: Scancode
 pattern ScancodeInsert = Scancode Raw.SDL_SCANCODE_INSERT
+pattern ScancodeHome :: Scancode
 pattern ScancodeHome = Scancode Raw.SDL_SCANCODE_HOME
+pattern ScancodePageUp :: Scancode
 pattern ScancodePageUp = Scancode Raw.SDL_SCANCODE_PAGEUP
+pattern ScancodeDelete :: Scancode
 pattern ScancodeDelete = Scancode Raw.SDL_SCANCODE_DELETE
+pattern ScancodeEnd :: Scancode
 pattern ScancodeEnd = Scancode Raw.SDL_SCANCODE_END
+pattern ScancodePageDown :: Scancode
 pattern ScancodePageDown = Scancode Raw.SDL_SCANCODE_PAGEDOWN
+pattern ScancodeRight :: Scancode
 pattern ScancodeRight = Scancode Raw.SDL_SCANCODE_RIGHT
+pattern ScancodeLeft :: Scancode
 pattern ScancodeLeft = Scancode Raw.SDL_SCANCODE_LEFT
+pattern ScancodeDown :: Scancode
 pattern ScancodeDown = Scancode Raw.SDL_SCANCODE_DOWN
+pattern ScancodeUp :: Scancode
 pattern ScancodeUp = Scancode Raw.SDL_SCANCODE_UP
+pattern ScancodeNumLockClear :: Scancode
 pattern ScancodeNumLockClear = Scancode Raw.SDL_SCANCODE_NUMLOCKCLEAR
+pattern ScancodeKPDivide :: Scancode
 pattern ScancodeKPDivide = Scancode Raw.SDL_SCANCODE_KP_DIVIDE
+pattern ScancodeKPMultiply :: Scancode
 pattern ScancodeKPMultiply = Scancode Raw.SDL_SCANCODE_KP_MULTIPLY
+pattern ScancodeKPMinus :: Scancode
 pattern ScancodeKPMinus = Scancode Raw.SDL_SCANCODE_KP_MINUS
+pattern ScancodeKPPlus :: Scancode
 pattern ScancodeKPPlus = Scancode Raw.SDL_SCANCODE_KP_PLUS
+pattern ScancodeKPEnter :: Scancode
 pattern ScancodeKPEnter = Scancode Raw.SDL_SCANCODE_KP_ENTER
+pattern ScancodeKP1 :: Scancode
 pattern ScancodeKP1 = Scancode Raw.SDL_SCANCODE_KP_1
+pattern ScancodeKP2 :: Scancode
 pattern ScancodeKP2 = Scancode Raw.SDL_SCANCODE_KP_2
+pattern ScancodeKP3 :: Scancode
 pattern ScancodeKP3 = Scancode Raw.SDL_SCANCODE_KP_3
+pattern ScancodeKP4 :: Scancode
 pattern ScancodeKP4 = Scancode Raw.SDL_SCANCODE_KP_4
+pattern ScancodeKP5 :: Scancode
 pattern ScancodeKP5 = Scancode Raw.SDL_SCANCODE_KP_5
+pattern ScancodeKP6 :: Scancode
 pattern ScancodeKP6 = Scancode Raw.SDL_SCANCODE_KP_6
+pattern ScancodeKP7 :: Scancode
 pattern ScancodeKP7 = Scancode Raw.SDL_SCANCODE_KP_7
+pattern ScancodeKP8 :: Scancode
 pattern ScancodeKP8 = Scancode Raw.SDL_SCANCODE_KP_8
+pattern ScancodeKP9 :: Scancode
 pattern ScancodeKP9 = Scancode Raw.SDL_SCANCODE_KP_9
+pattern ScancodeKP0 :: Scancode
 pattern ScancodeKP0 = Scancode Raw.SDL_SCANCODE_KP_0
+pattern ScancodeKPPeriod :: Scancode
 pattern ScancodeKPPeriod = Scancode Raw.SDL_SCANCODE_KP_PERIOD
+pattern ScancodeNonUSBackslash :: Scancode
 pattern ScancodeNonUSBackslash = Scancode Raw.SDL_SCANCODE_NONUSBACKSLASH
+pattern ScancodeApplication :: Scancode
 pattern ScancodeApplication = Scancode Raw.SDL_SCANCODE_APPLICATION
+pattern ScancodePower :: Scancode
 pattern ScancodePower = Scancode Raw.SDL_SCANCODE_POWER
+pattern ScancodeKPEquals :: Scancode
 pattern ScancodeKPEquals = Scancode Raw.SDL_SCANCODE_KP_EQUALS
+pattern ScancodeF13 :: Scancode
 pattern ScancodeF13 = Scancode Raw.SDL_SCANCODE_F13
+pattern ScancodeF14 :: Scancode
 pattern ScancodeF14 = Scancode Raw.SDL_SCANCODE_F14
+pattern ScancodeF15 :: Scancode
 pattern ScancodeF15 = Scancode Raw.SDL_SCANCODE_F15
+pattern ScancodeF16 :: Scancode
 pattern ScancodeF16 = Scancode Raw.SDL_SCANCODE_F16
+pattern ScancodeF17 :: Scancode
 pattern ScancodeF17 = Scancode Raw.SDL_SCANCODE_F17
+pattern ScancodeF18 :: Scancode
 pattern ScancodeF18 = Scancode Raw.SDL_SCANCODE_F18
+pattern ScancodeF19 :: Scancode
 pattern ScancodeF19 = Scancode Raw.SDL_SCANCODE_F19
+pattern ScancodeF20 :: Scancode
 pattern ScancodeF20 = Scancode Raw.SDL_SCANCODE_F20
+pattern ScancodeF21 :: Scancode
 pattern ScancodeF21 = Scancode Raw.SDL_SCANCODE_F21
+pattern ScancodeF22 :: Scancode
 pattern ScancodeF22 = Scancode Raw.SDL_SCANCODE_F22
+pattern ScancodeF23 :: Scancode
 pattern ScancodeF23 = Scancode Raw.SDL_SCANCODE_F23
+pattern ScancodeF24 :: Scancode
 pattern ScancodeF24 = Scancode Raw.SDL_SCANCODE_F24
+pattern ScancodeExecute :: Scancode
 pattern ScancodeExecute = Scancode Raw.SDL_SCANCODE_EXECUTE
+pattern ScancodeHelp :: Scancode
 pattern ScancodeHelp = Scancode Raw.SDL_SCANCODE_HELP
+pattern ScancodeMenu :: Scancode
 pattern ScancodeMenu = Scancode Raw.SDL_SCANCODE_MENU
+pattern ScancodeSelect :: Scancode
 pattern ScancodeSelect = Scancode Raw.SDL_SCANCODE_SELECT
+pattern ScancodeStop :: Scancode
 pattern ScancodeStop = Scancode Raw.SDL_SCANCODE_STOP
+pattern ScancodeAgain :: Scancode
 pattern ScancodeAgain = Scancode Raw.SDL_SCANCODE_AGAIN
+pattern ScancodeUndo :: Scancode
 pattern ScancodeUndo = Scancode Raw.SDL_SCANCODE_UNDO
+pattern ScancodeCut :: Scancode
 pattern ScancodeCut = Scancode Raw.SDL_SCANCODE_CUT
+pattern ScancodeCopy :: Scancode
 pattern ScancodeCopy = Scancode Raw.SDL_SCANCODE_COPY
+pattern ScancodePaste :: Scancode
 pattern ScancodePaste = Scancode Raw.SDL_SCANCODE_PASTE
+pattern ScancodeFind :: Scancode
 pattern ScancodeFind = Scancode Raw.SDL_SCANCODE_FIND
+pattern ScancodeMute :: Scancode
 pattern ScancodeMute = Scancode Raw.SDL_SCANCODE_MUTE
+pattern ScancodeVolumeUp :: Scancode
 pattern ScancodeVolumeUp = Scancode Raw.SDL_SCANCODE_VOLUMEUP
+pattern ScancodeVolumeDown :: Scancode
 pattern ScancodeVolumeDown = Scancode Raw.SDL_SCANCODE_VOLUMEDOWN
+pattern ScancodeKPComma :: Scancode
 pattern ScancodeKPComma = Scancode Raw.SDL_SCANCODE_KP_COMMA
+pattern ScancodeKPEqualsAS400 :: Scancode
 pattern ScancodeKPEqualsAS400 = Scancode Raw.SDL_SCANCODE_KP_EQUALSAS400
+pattern ScancodeInternational1 :: Scancode
 pattern ScancodeInternational1 = Scancode Raw.SDL_SCANCODE_INTERNATIONAL1
+pattern ScancodeInternational2 :: Scancode
 pattern ScancodeInternational2 = Scancode Raw.SDL_SCANCODE_INTERNATIONAL2
+pattern ScancodeInternational3 :: Scancode
 pattern ScancodeInternational3 = Scancode Raw.SDL_SCANCODE_INTERNATIONAL3
+pattern ScancodeInternational4 :: Scancode
 pattern ScancodeInternational4 = Scancode Raw.SDL_SCANCODE_INTERNATIONAL4
+pattern ScancodeInternational5 :: Scancode
 pattern ScancodeInternational5 = Scancode Raw.SDL_SCANCODE_INTERNATIONAL5
+pattern ScancodeInternational6 :: Scancode
 pattern ScancodeInternational6 = Scancode Raw.SDL_SCANCODE_INTERNATIONAL6
+pattern ScancodeInternational7 :: Scancode
 pattern ScancodeInternational7 = Scancode Raw.SDL_SCANCODE_INTERNATIONAL7
+pattern ScancodeInternational8 :: Scancode
 pattern ScancodeInternational8 = Scancode Raw.SDL_SCANCODE_INTERNATIONAL8
+pattern ScancodeInternational9 :: Scancode
 pattern ScancodeInternational9 = Scancode Raw.SDL_SCANCODE_INTERNATIONAL9
+pattern ScancodeLang1 :: Scancode
 pattern ScancodeLang1 = Scancode Raw.SDL_SCANCODE_LANG1
+pattern ScancodeLang2 :: Scancode
 pattern ScancodeLang2 = Scancode Raw.SDL_SCANCODE_LANG2
+pattern ScancodeLang3 :: Scancode
 pattern ScancodeLang3 = Scancode Raw.SDL_SCANCODE_LANG3
+pattern ScancodeLang4 :: Scancode
 pattern ScancodeLang4 = Scancode Raw.SDL_SCANCODE_LANG4
+pattern ScancodeLang5 :: Scancode
 pattern ScancodeLang5 = Scancode Raw.SDL_SCANCODE_LANG5
+pattern ScancodeLang6 :: Scancode
 pattern ScancodeLang6 = Scancode Raw.SDL_SCANCODE_LANG6
+pattern ScancodeLang7 :: Scancode
 pattern ScancodeLang7 = Scancode Raw.SDL_SCANCODE_LANG7
+pattern ScancodeLang8 :: Scancode
 pattern ScancodeLang8 = Scancode Raw.SDL_SCANCODE_LANG8
+pattern ScancodeLang9 :: Scancode
 pattern ScancodeLang9 = Scancode Raw.SDL_SCANCODE_LANG9
+pattern ScancodeAltErase :: Scancode
 pattern ScancodeAltErase = Scancode Raw.SDL_SCANCODE_ALTERASE
+pattern ScancodeSysReq :: Scancode
 pattern ScancodeSysReq = Scancode Raw.SDL_SCANCODE_SYSREQ
+pattern ScancodeCancel :: Scancode
 pattern ScancodeCancel = Scancode Raw.SDL_SCANCODE_CANCEL
+pattern ScancodeClear :: Scancode
 pattern ScancodeClear = Scancode Raw.SDL_SCANCODE_CLEAR
+pattern ScancodePrior :: Scancode
 pattern ScancodePrior = Scancode Raw.SDL_SCANCODE_PRIOR
+pattern ScancodeReturn2 :: Scancode
 pattern ScancodeReturn2 = Scancode Raw.SDL_SCANCODE_RETURN2
+pattern ScancodeSeparator :: Scancode
 pattern ScancodeSeparator = Scancode Raw.SDL_SCANCODE_SEPARATOR
+pattern ScancodeOut :: Scancode
 pattern ScancodeOut = Scancode Raw.SDL_SCANCODE_OUT
+pattern ScancodeOper :: Scancode
 pattern ScancodeOper = Scancode Raw.SDL_SCANCODE_OPER
+pattern ScancodeClearAgain :: Scancode
 pattern ScancodeClearAgain = Scancode Raw.SDL_SCANCODE_CLEARAGAIN
+pattern ScancodeCrSel :: Scancode
 pattern ScancodeCrSel = Scancode Raw.SDL_SCANCODE_CRSEL
+pattern ScancodeExSel :: Scancode
 pattern ScancodeExSel = Scancode Raw.SDL_SCANCODE_EXSEL
+pattern ScancodeKP00 :: Scancode
 pattern ScancodeKP00 = Scancode Raw.SDL_SCANCODE_KP_00
+pattern ScancodeKP000 :: Scancode
 pattern ScancodeKP000 = Scancode Raw.SDL_SCANCODE_KP_000
+pattern ScancodeThousandsSeparator :: Scancode
 pattern ScancodeThousandsSeparator = Scancode Raw.SDL_SCANCODE_THOUSANDSSEPARATOR
+pattern ScancodeDecimalSeparator :: Scancode
 pattern ScancodeDecimalSeparator = Scancode Raw.SDL_SCANCODE_DECIMALSEPARATOR
+pattern ScancodeCurrencyUnit :: Scancode
 pattern ScancodeCurrencyUnit = Scancode Raw.SDL_SCANCODE_CURRENCYUNIT
+pattern ScancodeCurrencySubunit :: Scancode
 pattern ScancodeCurrencySubunit = Scancode Raw.SDL_SCANCODE_CURRENCYSUBUNIT
+pattern ScancodeLeftParen :: Scancode
 pattern ScancodeLeftParen = Scancode Raw.SDL_SCANCODE_KP_LEFTPAREN
+pattern ScancodeRightParen :: Scancode
 pattern ScancodeRightParen = Scancode Raw.SDL_SCANCODE_KP_RIGHTPAREN
+pattern ScancodeLeftBrace :: Scancode
 pattern ScancodeLeftBrace = Scancode Raw.SDL_SCANCODE_KP_LEFTBRACE
+pattern ScancodeRightBrace :: Scancode
 pattern ScancodeRightBrace = Scancode Raw.SDL_SCANCODE_KP_RIGHTBRACE
+pattern ScancodeKPTab :: Scancode
 pattern ScancodeKPTab = Scancode Raw.SDL_SCANCODE_KP_TAB
+pattern ScancodeKPBackspace :: Scancode
 pattern ScancodeKPBackspace = Scancode Raw.SDL_SCANCODE_KP_BACKSPACE
+pattern ScancodeKPA :: Scancode
 pattern ScancodeKPA = Scancode Raw.SDL_SCANCODE_KP_A
+pattern ScancodeKPB :: Scancode
 pattern ScancodeKPB = Scancode Raw.SDL_SCANCODE_KP_B
+pattern ScancodeKPC :: Scancode
 pattern ScancodeKPC = Scancode Raw.SDL_SCANCODE_KP_C
+pattern ScancodeKPD :: Scancode
 pattern ScancodeKPD = Scancode Raw.SDL_SCANCODE_KP_D
+pattern ScancodeKPE :: Scancode
 pattern ScancodeKPE = Scancode Raw.SDL_SCANCODE_KP_E
+pattern ScancodeKPF :: Scancode
 pattern ScancodeKPF = Scancode Raw.SDL_SCANCODE_KP_F
+pattern ScancodeKPXOR :: Scancode
 pattern ScancodeKPXOR = Scancode Raw.SDL_SCANCODE_KP_XOR
+pattern ScancodeKPPower :: Scancode
 pattern ScancodeKPPower = Scancode Raw.SDL_SCANCODE_KP_POWER
+pattern ScancodeKPPercent :: Scancode
 pattern ScancodeKPPercent = Scancode Raw.SDL_SCANCODE_KP_PERCENT
+pattern ScancodeKPLess :: Scancode
 pattern ScancodeKPLess = Scancode Raw.SDL_SCANCODE_KP_LESS
+pattern ScancodeKPGreater :: Scancode
 pattern ScancodeKPGreater = Scancode Raw.SDL_SCANCODE_KP_GREATER
+pattern ScancodeKPAmpersand :: Scancode
 pattern ScancodeKPAmpersand = Scancode Raw.SDL_SCANCODE_KP_AMPERSAND
+pattern ScancodeKPDblAmpersand :: Scancode
 pattern ScancodeKPDblAmpersand = Scancode Raw.SDL_SCANCODE_KP_DBLAMPERSAND
+pattern ScancodeKPVerticalBar :: Scancode
 pattern ScancodeKPVerticalBar = Scancode Raw.SDL_SCANCODE_KP_VERTICALBAR
+pattern ScancodeKPDblVerticalBar :: Scancode
 pattern ScancodeKPDblVerticalBar = Scancode Raw.SDL_SCANCODE_KP_DBLVERTICALBAR
+pattern ScancodeKPColon :: Scancode
 pattern ScancodeKPColon = Scancode Raw.SDL_SCANCODE_KP_COLON
+pattern ScancodeKPHash :: Scancode
 pattern ScancodeKPHash = Scancode Raw.SDL_SCANCODE_KP_HASH
+pattern ScancodeKPSpace :: Scancode
 pattern ScancodeKPSpace = Scancode Raw.SDL_SCANCODE_KP_SPACE
+pattern ScancodeKPAt :: Scancode
 pattern ScancodeKPAt = Scancode Raw.SDL_SCANCODE_KP_AT
+pattern ScancodeKPExclam :: Scancode
 pattern ScancodeKPExclam = Scancode Raw.SDL_SCANCODE_KP_EXCLAM
+pattern ScancodeKPMemStore :: Scancode
 pattern ScancodeKPMemStore = Scancode Raw.SDL_SCANCODE_KP_MEMSTORE
+pattern ScancodeKPMemRecall :: Scancode
 pattern ScancodeKPMemRecall = Scancode Raw.SDL_SCANCODE_KP_MEMRECALL
+pattern ScancodeKPMemClear :: Scancode
 pattern ScancodeKPMemClear = Scancode Raw.SDL_SCANCODE_KP_MEMCLEAR
+pattern ScancodeKPMemAdd :: Scancode
 pattern ScancodeKPMemAdd = Scancode Raw.SDL_SCANCODE_KP_MEMADD
+pattern ScancodeKPMemSubtract :: Scancode
 pattern ScancodeKPMemSubtract = Scancode Raw.SDL_SCANCODE_KP_MEMSUBTRACT
+pattern ScancodeKPMemMultiply :: Scancode
 pattern ScancodeKPMemMultiply = Scancode Raw.SDL_SCANCODE_KP_MEMMULTIPLY
+pattern ScancodeKPMemDivide :: Scancode
 pattern ScancodeKPMemDivide = Scancode Raw.SDL_SCANCODE_KP_MEMDIVIDE
+pattern ScancodeKPPlusMinus :: Scancode
 pattern ScancodeKPPlusMinus = Scancode Raw.SDL_SCANCODE_KP_PLUSMINUS
+pattern ScancodeKPClear :: Scancode
 pattern ScancodeKPClear = Scancode Raw.SDL_SCANCODE_KP_CLEAR
+pattern ScancodeKPClearEntry :: Scancode
 pattern ScancodeKPClearEntry = Scancode Raw.SDL_SCANCODE_KP_CLEARENTRY
+pattern ScancodeKPBinary :: Scancode
 pattern ScancodeKPBinary = Scancode Raw.SDL_SCANCODE_KP_BINARY
+pattern ScancodeKPOctal :: Scancode
 pattern ScancodeKPOctal = Scancode Raw.SDL_SCANCODE_KP_OCTAL
+pattern ScancodeKPDecimal :: Scancode
 pattern ScancodeKPDecimal = Scancode Raw.SDL_SCANCODE_KP_DECIMAL
+pattern ScancodeKPHexadecimal :: Scancode
 pattern ScancodeKPHexadecimal = Scancode Raw.SDL_SCANCODE_KP_HEXADECIMAL
+pattern ScancodeLCtrl :: Scancode
 pattern ScancodeLCtrl = Scancode Raw.SDL_SCANCODE_LCTRL
+pattern ScancodeLShift :: Scancode
 pattern ScancodeLShift = Scancode Raw.SDL_SCANCODE_LSHIFT
+pattern ScancodeLAlt :: Scancode
 pattern ScancodeLAlt = Scancode Raw.SDL_SCANCODE_LALT
+pattern ScancodeLGUI :: Scancode
 pattern ScancodeLGUI = Scancode Raw.SDL_SCANCODE_LGUI
+pattern ScancodeRCtrl :: Scancode
 pattern ScancodeRCtrl = Scancode Raw.SDL_SCANCODE_RCTRL
+pattern ScancodeRShift :: Scancode
 pattern ScancodeRShift = Scancode Raw.SDL_SCANCODE_RSHIFT
+pattern ScancodeRAlt :: Scancode
 pattern ScancodeRAlt = Scancode Raw.SDL_SCANCODE_RALT
+pattern ScancodeRGUI :: Scancode
 pattern ScancodeRGUI = Scancode Raw.SDL_SCANCODE_RGUI
+pattern ScancodeMode :: Scancode
 pattern ScancodeMode = Scancode Raw.SDL_SCANCODE_MODE
+pattern ScancodeAudioNext :: Scancode
 pattern ScancodeAudioNext = Scancode Raw.SDL_SCANCODE_AUDIONEXT
+pattern ScancodeAudioPrev :: Scancode
 pattern ScancodeAudioPrev = Scancode Raw.SDL_SCANCODE_AUDIOPREV
+pattern ScancodeAudioStop :: Scancode
 pattern ScancodeAudioStop = Scancode Raw.SDL_SCANCODE_AUDIOSTOP
+pattern ScancodeAudioPlay :: Scancode
 pattern ScancodeAudioPlay = Scancode Raw.SDL_SCANCODE_AUDIOPLAY
+pattern ScancodeAudioMute :: Scancode
 pattern ScancodeAudioMute = Scancode Raw.SDL_SCANCODE_AUDIOMUTE
+pattern ScancodeMediaSelect :: Scancode
 pattern ScancodeMediaSelect = Scancode Raw.SDL_SCANCODE_MEDIASELECT
+pattern ScancodeWWW :: Scancode
 pattern ScancodeWWW = Scancode Raw.SDL_SCANCODE_WWW
+pattern ScancodeMail :: Scancode
 pattern ScancodeMail = Scancode Raw.SDL_SCANCODE_MAIL
+pattern ScancodeCalculator :: Scancode
 pattern ScancodeCalculator = Scancode Raw.SDL_SCANCODE_CALCULATOR
+pattern ScancodeComputer :: Scancode
 pattern ScancodeComputer = Scancode Raw.SDL_SCANCODE_COMPUTER
+pattern ScancodeACSearch :: Scancode
 pattern ScancodeACSearch = Scancode Raw.SDL_SCANCODE_AC_SEARCH
+pattern ScancodeACHome :: Scancode
 pattern ScancodeACHome = Scancode Raw.SDL_SCANCODE_AC_HOME
+pattern ScancodeACBack :: Scancode
 pattern ScancodeACBack = Scancode Raw.SDL_SCANCODE_AC_BACK
+pattern ScancodeACForward :: Scancode
 pattern ScancodeACForward = Scancode Raw.SDL_SCANCODE_AC_FORWARD
+pattern ScancodeACStop :: Scancode
 pattern ScancodeACStop = Scancode Raw.SDL_SCANCODE_AC_STOP
+pattern ScancodeACRefresh :: Scancode
 pattern ScancodeACRefresh = Scancode Raw.SDL_SCANCODE_AC_REFRESH
+pattern ScancodeACBookmarks :: Scancode
 pattern ScancodeACBookmarks = Scancode Raw.SDL_SCANCODE_AC_BOOKMARKS
+pattern ScancodeBrightnessDown :: Scancode
 pattern ScancodeBrightnessDown = Scancode Raw.SDL_SCANCODE_BRIGHTNESSDOWN
+pattern ScancodeBrightnessUp :: Scancode
 pattern ScancodeBrightnessUp = Scancode Raw.SDL_SCANCODE_BRIGHTNESSUP
+pattern ScancodeDisplaySwitch :: Scancode
 pattern ScancodeDisplaySwitch = Scancode Raw.SDL_SCANCODE_DISPLAYSWITCH
+pattern ScancodeKBDIllumToggle :: Scancode
 pattern ScancodeKBDIllumToggle = Scancode Raw.SDL_SCANCODE_KBDILLUMTOGGLE
+pattern ScancodeKBDIllumDown :: Scancode
 pattern ScancodeKBDIllumDown = Scancode Raw.SDL_SCANCODE_KBDILLUMDOWN
+pattern ScancodeKBDIllumUp :: Scancode
 pattern ScancodeKBDIllumUp = Scancode Raw.SDL_SCANCODE_KBDILLUMUP
+pattern ScancodeEject :: Scancode
 pattern ScancodeEject = Scancode Raw.SDL_SCANCODE_EJECT
+pattern ScancodeSleep :: Scancode
 pattern ScancodeSleep = Scancode Raw.SDL_SCANCODE_SLEEP
+pattern ScancodeApp1 :: Scancode
 pattern ScancodeApp1 = Scancode Raw.SDL_SCANCODE_APP1
+pattern ScancodeApp2 :: Scancode
 pattern ScancodeApp2 = Scancode Raw.SDL_SCANCODE_APP2
 
 instance FromNumber Scancode Word32 where
@@ -767,241 +1008,477 @@ instance ToNumber Scancode Word32 where
 newtype Keycode = Keycode { unwrapKeycode :: Int32 }
   deriving (Bounded, Data, Eq, Ord, Read, Generic, Show, Typeable)
 
+pattern KeycodeUnknown :: Keycode
 pattern KeycodeUnknown = Keycode Raw.SDLK_UNKNOWN
+pattern KeycodeReturn :: Keycode
 pattern KeycodeReturn = Keycode Raw.SDLK_RETURN
+pattern KeycodeEscape :: Keycode
 pattern KeycodeEscape = Keycode Raw.SDLK_ESCAPE
+pattern KeycodeBackspace :: Keycode
 pattern KeycodeBackspace = Keycode Raw.SDLK_BACKSPACE
+pattern KeycodeTab :: Keycode
 pattern KeycodeTab = Keycode Raw.SDLK_TAB
+pattern KeycodeSpace :: Keycode
 pattern KeycodeSpace = Keycode Raw.SDLK_SPACE
+pattern KeycodeExclaim :: Keycode
 pattern KeycodeExclaim = Keycode Raw.SDLK_EXCLAIM
+pattern KeycodeQuoteDbl :: Keycode
 pattern KeycodeQuoteDbl = Keycode Raw.SDLK_QUOTEDBL
+pattern KeycodeHash :: Keycode
 pattern KeycodeHash = Keycode Raw.SDLK_HASH
+pattern KeycodePercent :: Keycode
 pattern KeycodePercent = Keycode Raw.SDLK_PERCENT
+pattern KeycodeDollar :: Keycode
 pattern KeycodeDollar = Keycode Raw.SDLK_DOLLAR
+pattern KeycodeAmpersand :: Keycode
 pattern KeycodeAmpersand = Keycode Raw.SDLK_AMPERSAND
+pattern KeycodeQuote :: Keycode
 pattern KeycodeQuote = Keycode Raw.SDLK_QUOTE
+pattern KeycodeLeftParen :: Keycode
 pattern KeycodeLeftParen = Keycode Raw.SDLK_LEFTPAREN
+pattern KeycodeRightParen :: Keycode
 pattern KeycodeRightParen = Keycode Raw.SDLK_RIGHTPAREN
+pattern KeycodeAsterisk :: Keycode
 pattern KeycodeAsterisk = Keycode Raw.SDLK_ASTERISK
+pattern KeycodePlus :: Keycode
 pattern KeycodePlus = Keycode Raw.SDLK_PLUS
+pattern KeycodeComma :: Keycode
 pattern KeycodeComma = Keycode Raw.SDLK_COMMA
+pattern KeycodeMinus :: Keycode
 pattern KeycodeMinus = Keycode Raw.SDLK_MINUS
+pattern KeycodePeriod :: Keycode
 pattern KeycodePeriod = Keycode Raw.SDLK_PERIOD
+pattern KeycodeSlash :: Keycode
 pattern KeycodeSlash = Keycode Raw.SDLK_SLASH
+pattern Keycode0 :: Keycode
 pattern Keycode0 = Keycode Raw.SDLK_0
+pattern Keycode1 :: Keycode
 pattern Keycode1 = Keycode Raw.SDLK_1
+pattern Keycode2 :: Keycode
 pattern Keycode2 = Keycode Raw.SDLK_2
+pattern Keycode3 :: Keycode
 pattern Keycode3 = Keycode Raw.SDLK_3
+pattern Keycode4 :: Keycode
 pattern Keycode4 = Keycode Raw.SDLK_4
+pattern Keycode5 :: Keycode
 pattern Keycode5 = Keycode Raw.SDLK_5
+pattern Keycode6 :: Keycode
 pattern Keycode6 = Keycode Raw.SDLK_6
+pattern Keycode7 :: Keycode
 pattern Keycode7 = Keycode Raw.SDLK_7
+pattern Keycode8 :: Keycode
 pattern Keycode8 = Keycode Raw.SDLK_8
+pattern Keycode9 :: Keycode
 pattern Keycode9 = Keycode Raw.SDLK_9
+pattern KeycodeColon :: Keycode
 pattern KeycodeColon = Keycode Raw.SDLK_COLON
+pattern KeycodeSemicolon :: Keycode
 pattern KeycodeSemicolon = Keycode Raw.SDLK_SEMICOLON
+pattern KeycodeLess :: Keycode
 pattern KeycodeLess = Keycode Raw.SDLK_LESS
+pattern KeycodeEquals :: Keycode
 pattern KeycodeEquals = Keycode Raw.SDLK_EQUALS
+pattern KeycodeGreater :: Keycode
 pattern KeycodeGreater = Keycode Raw.SDLK_GREATER
+pattern KeycodeQuestion :: Keycode
 pattern KeycodeQuestion = Keycode Raw.SDLK_QUESTION
+pattern KeycodeAt :: Keycode
 pattern KeycodeAt = Keycode Raw.SDLK_AT
+pattern KeycodeLeftBracket :: Keycode
 pattern KeycodeLeftBracket = Keycode Raw.SDLK_LEFTBRACKET
+pattern KeycodeBackslash :: Keycode
 pattern KeycodeBackslash = Keycode Raw.SDLK_BACKSLASH
+pattern KeycodeRightBracket :: Keycode
 pattern KeycodeRightBracket = Keycode Raw.SDLK_RIGHTBRACKET
+pattern KeycodeCaret :: Keycode
 pattern KeycodeCaret = Keycode Raw.SDLK_CARET
+pattern KeycodeUnderscore :: Keycode
 pattern KeycodeUnderscore = Keycode Raw.SDLK_UNDERSCORE
+pattern KeycodeBackquote :: Keycode
 pattern KeycodeBackquote = Keycode Raw.SDLK_BACKQUOTE
+pattern KeycodeA :: Keycode
 pattern KeycodeA = Keycode Raw.SDLK_a
+pattern KeycodeB :: Keycode
 pattern KeycodeB = Keycode Raw.SDLK_b
+pattern KeycodeC :: Keycode
 pattern KeycodeC = Keycode Raw.SDLK_c
+pattern KeycodeD :: Keycode
 pattern KeycodeD = Keycode Raw.SDLK_d
+pattern KeycodeE :: Keycode
 pattern KeycodeE = Keycode Raw.SDLK_e
+pattern KeycodeF :: Keycode
 pattern KeycodeF = Keycode Raw.SDLK_f
+pattern KeycodeG :: Keycode
 pattern KeycodeG = Keycode Raw.SDLK_g
+pattern KeycodeH :: Keycode
 pattern KeycodeH = Keycode Raw.SDLK_h
+pattern KeycodeI :: Keycode
 pattern KeycodeI = Keycode Raw.SDLK_i
+pattern KeycodeJ :: Keycode
 pattern KeycodeJ = Keycode Raw.SDLK_j
+pattern KeycodeK :: Keycode
 pattern KeycodeK = Keycode Raw.SDLK_k
+pattern KeycodeL :: Keycode
 pattern KeycodeL = Keycode Raw.SDLK_l
+pattern KeycodeM :: Keycode
 pattern KeycodeM = Keycode Raw.SDLK_m
+pattern KeycodeN :: Keycode
 pattern KeycodeN = Keycode Raw.SDLK_n
+pattern KeycodeO :: Keycode
 pattern KeycodeO = Keycode Raw.SDLK_o
+pattern KeycodeP :: Keycode
 pattern KeycodeP = Keycode Raw.SDLK_p
+pattern KeycodeQ :: Keycode
 pattern KeycodeQ = Keycode Raw.SDLK_q
+pattern KeycodeR :: Keycode
 pattern KeycodeR = Keycode Raw.SDLK_r
+pattern KeycodeS :: Keycode
 pattern KeycodeS = Keycode Raw.SDLK_s
+pattern KeycodeT :: Keycode
 pattern KeycodeT = Keycode Raw.SDLK_t
+pattern KeycodeU :: Keycode
 pattern KeycodeU = Keycode Raw.SDLK_u
+pattern KeycodeV :: Keycode
 pattern KeycodeV = Keycode Raw.SDLK_v
+pattern KeycodeW :: Keycode
 pattern KeycodeW = Keycode Raw.SDLK_w
+pattern KeycodeX :: Keycode
 pattern KeycodeX = Keycode Raw.SDLK_x
+pattern KeycodeY :: Keycode
 pattern KeycodeY = Keycode Raw.SDLK_y
+pattern KeycodeZ :: Keycode
 pattern KeycodeZ = Keycode Raw.SDLK_z
+pattern KeycodeCapsLock :: Keycode
 pattern KeycodeCapsLock = Keycode Raw.SDLK_CAPSLOCK
+pattern KeycodeF1 :: Keycode
 pattern KeycodeF1 = Keycode Raw.SDLK_F1
+pattern KeycodeF2 :: Keycode
 pattern KeycodeF2 = Keycode Raw.SDLK_F2
+pattern KeycodeF3 :: Keycode
 pattern KeycodeF3 = Keycode Raw.SDLK_F3
+pattern KeycodeF4 :: Keycode
 pattern KeycodeF4 = Keycode Raw.SDLK_F4
+pattern KeycodeF5 :: Keycode
 pattern KeycodeF5 = Keycode Raw.SDLK_F5
+pattern KeycodeF6 :: Keycode
 pattern KeycodeF6 = Keycode Raw.SDLK_F6
+pattern KeycodeF7 :: Keycode
 pattern KeycodeF7 = Keycode Raw.SDLK_F7
+pattern KeycodeF8 :: Keycode
 pattern KeycodeF8 = Keycode Raw.SDLK_F8
+pattern KeycodeF9 :: Keycode
 pattern KeycodeF9 = Keycode Raw.SDLK_F9
+pattern KeycodeF10 :: Keycode
 pattern KeycodeF10 = Keycode Raw.SDLK_F10
+pattern KeycodeF11 :: Keycode
 pattern KeycodeF11 = Keycode Raw.SDLK_F11
+pattern KeycodeF12 :: Keycode
 pattern KeycodeF12 = Keycode Raw.SDLK_F12
+pattern KeycodePrintScreen :: Keycode
 pattern KeycodePrintScreen = Keycode Raw.SDLK_PRINTSCREEN
+pattern KeycodeScrollLock :: Keycode
 pattern KeycodeScrollLock = Keycode Raw.SDLK_SCROLLLOCK
+pattern KeycodePause :: Keycode
 pattern KeycodePause = Keycode Raw.SDLK_PAUSE
+pattern KeycodeInsert :: Keycode
 pattern KeycodeInsert = Keycode Raw.SDLK_INSERT
+pattern KeycodeHome :: Keycode
 pattern KeycodeHome = Keycode Raw.SDLK_HOME
+pattern KeycodePageUp :: Keycode
 pattern KeycodePageUp = Keycode Raw.SDLK_PAGEUP
+pattern KeycodeDelete :: Keycode
 pattern KeycodeDelete = Keycode Raw.SDLK_DELETE
+pattern KeycodeEnd :: Keycode
 pattern KeycodeEnd = Keycode Raw.SDLK_END
+pattern KeycodePageDown :: Keycode
 pattern KeycodePageDown = Keycode Raw.SDLK_PAGEDOWN
+pattern KeycodeRight :: Keycode
 pattern KeycodeRight = Keycode Raw.SDLK_RIGHT
+pattern KeycodeLeft :: Keycode
 pattern KeycodeLeft = Keycode Raw.SDLK_LEFT
+pattern KeycodeDown :: Keycode
 pattern KeycodeDown = Keycode Raw.SDLK_DOWN
+pattern KeycodeUp :: Keycode
 pattern KeycodeUp = Keycode Raw.SDLK_UP
+pattern KeycodeNumLockClear :: Keycode
 pattern KeycodeNumLockClear = Keycode Raw.SDLK_NUMLOCKCLEAR
+pattern KeycodeKPDivide :: Keycode
 pattern KeycodeKPDivide = Keycode Raw.SDLK_KP_DIVIDE
+pattern KeycodeKPMultiply :: Keycode
 pattern KeycodeKPMultiply = Keycode Raw.SDLK_KP_MULTIPLY
+pattern KeycodeKPMinus :: Keycode
 pattern KeycodeKPMinus = Keycode Raw.SDLK_KP_MINUS
+pattern KeycodeKPPlus :: Keycode
 pattern KeycodeKPPlus = Keycode Raw.SDLK_KP_PLUS
+pattern KeycodeKPEnter :: Keycode
 pattern KeycodeKPEnter = Keycode Raw.SDLK_KP_ENTER
+pattern KeycodeKP1 :: Keycode
 pattern KeycodeKP1 = Keycode Raw.SDLK_KP_1
+pattern KeycodeKP2 :: Keycode
 pattern KeycodeKP2 = Keycode Raw.SDLK_KP_2
+pattern KeycodeKP3 :: Keycode
 pattern KeycodeKP3 = Keycode Raw.SDLK_KP_3
+pattern KeycodeKP4 :: Keycode
 pattern KeycodeKP4 = Keycode Raw.SDLK_KP_4
+pattern KeycodeKP5 :: Keycode
 pattern KeycodeKP5 = Keycode Raw.SDLK_KP_5
+pattern KeycodeKP6 :: Keycode
 pattern KeycodeKP6 = Keycode Raw.SDLK_KP_6
+pattern KeycodeKP7 :: Keycode
 pattern KeycodeKP7 = Keycode Raw.SDLK_KP_7
+pattern KeycodeKP8 :: Keycode
 pattern KeycodeKP8 = Keycode Raw.SDLK_KP_8
+pattern KeycodeKP9 :: Keycode
 pattern KeycodeKP9 = Keycode Raw.SDLK_KP_9
+pattern KeycodeKP0 :: Keycode
 pattern KeycodeKP0 = Keycode Raw.SDLK_KP_0
+pattern KeycodeKPPeriod :: Keycode
 pattern KeycodeKPPeriod = Keycode Raw.SDLK_KP_PERIOD
+pattern KeycodeApplication :: Keycode
 pattern KeycodeApplication = Keycode Raw.SDLK_APPLICATION
+pattern KeycodePower :: Keycode
 pattern KeycodePower = Keycode Raw.SDLK_POWER
+pattern KeycodeKPEquals :: Keycode
 pattern KeycodeKPEquals = Keycode Raw.SDLK_KP_EQUALS
+pattern KeycodeF13 :: Keycode
 pattern KeycodeF13 = Keycode Raw.SDLK_F13
+pattern KeycodeF14 :: Keycode
 pattern KeycodeF14 = Keycode Raw.SDLK_F14
+pattern KeycodeF15 :: Keycode
 pattern KeycodeF15 = Keycode Raw.SDLK_F15
+pattern KeycodeF16 :: Keycode
 pattern KeycodeF16 = Keycode Raw.SDLK_F16
+pattern KeycodeF17 :: Keycode
 pattern KeycodeF17 = Keycode Raw.SDLK_F17
+pattern KeycodeF18 :: Keycode
 pattern KeycodeF18 = Keycode Raw.SDLK_F18
+pattern KeycodeF19 :: Keycode
 pattern KeycodeF19 = Keycode Raw.SDLK_F19
+pattern KeycodeF20 :: Keycode
 pattern KeycodeF20 = Keycode Raw.SDLK_F20
+pattern KeycodeF21 :: Keycode
 pattern KeycodeF21 = Keycode Raw.SDLK_F21
+pattern KeycodeF22 :: Keycode
 pattern KeycodeF22 = Keycode Raw.SDLK_F22
+pattern KeycodeF23 :: Keycode
 pattern KeycodeF23 = Keycode Raw.SDLK_F23
+pattern KeycodeF24 :: Keycode
 pattern KeycodeF24 = Keycode Raw.SDLK_F24
+pattern KeycodeExecute :: Keycode
 pattern KeycodeExecute = Keycode Raw.SDLK_EXECUTE
+pattern KeycodeHelp :: Keycode
 pattern KeycodeHelp = Keycode Raw.SDLK_HELP
+pattern KeycodeMenu :: Keycode
 pattern KeycodeMenu = Keycode Raw.SDLK_MENU
+pattern KeycodeSelect :: Keycode
 pattern KeycodeSelect = Keycode Raw.SDLK_SELECT
+pattern KeycodeStop :: Keycode
 pattern KeycodeStop = Keycode Raw.SDLK_STOP
+pattern KeycodeAgain :: Keycode
 pattern KeycodeAgain = Keycode Raw.SDLK_AGAIN
+pattern KeycodeUndo :: Keycode
 pattern KeycodeUndo = Keycode Raw.SDLK_UNDO
+pattern KeycodeCut :: Keycode
 pattern KeycodeCut = Keycode Raw.SDLK_CUT
+pattern KeycodeCopy :: Keycode
 pattern KeycodeCopy = Keycode Raw.SDLK_COPY
+pattern KeycodePaste :: Keycode
 pattern KeycodePaste = Keycode Raw.SDLK_PASTE
+pattern KeycodeFind :: Keycode
 pattern KeycodeFind = Keycode Raw.SDLK_FIND
+pattern KeycodeMute :: Keycode
 pattern KeycodeMute = Keycode Raw.SDLK_MUTE
+pattern KeycodeVolumeUp :: Keycode
 pattern KeycodeVolumeUp = Keycode Raw.SDLK_VOLUMEUP
+pattern KeycodeVolumeDown :: Keycode
 pattern KeycodeVolumeDown = Keycode Raw.SDLK_VOLUMEDOWN
+pattern KeycodeKPComma :: Keycode
 pattern KeycodeKPComma = Keycode Raw.SDLK_KP_COMMA
+pattern KeycodeKPEqualsAS400 :: Keycode
 pattern KeycodeKPEqualsAS400 = Keycode Raw.SDLK_KP_EQUALSAS400
+pattern KeycodeAltErase :: Keycode
 pattern KeycodeAltErase = Keycode Raw.SDLK_ALTERASE
+pattern KeycodeSysReq :: Keycode
 pattern KeycodeSysReq = Keycode Raw.SDLK_SYSREQ
+pattern KeycodeCancel :: Keycode
 pattern KeycodeCancel = Keycode Raw.SDLK_CANCEL
+pattern KeycodeClear :: Keycode
 pattern KeycodeClear = Keycode Raw.SDLK_CLEAR
+pattern KeycodePrior :: Keycode
 pattern KeycodePrior = Keycode Raw.SDLK_PRIOR
+pattern KeycodeReturn2 :: Keycode
 pattern KeycodeReturn2 = Keycode Raw.SDLK_RETURN2
+pattern KeycodeSeparator :: Keycode
 pattern KeycodeSeparator = Keycode Raw.SDLK_SEPARATOR
+pattern KeycodeOut :: Keycode
 pattern KeycodeOut = Keycode Raw.SDLK_OUT
+pattern KeycodeOper :: Keycode
 pattern KeycodeOper = Keycode Raw.SDLK_OPER
+pattern KeycodeClearAgain :: Keycode
 pattern KeycodeClearAgain = Keycode Raw.SDLK_CLEARAGAIN
+pattern KeycodeCrSel :: Keycode
 pattern KeycodeCrSel = Keycode Raw.SDLK_CRSEL
+pattern KeycodeExSel :: Keycode
 pattern KeycodeExSel = Keycode Raw.SDLK_EXSEL
+pattern KeycodeKP00 :: Keycode
 pattern KeycodeKP00 = Keycode Raw.SDLK_KP_00
+pattern KeycodeKP000 :: Keycode
 pattern KeycodeKP000 = Keycode Raw.SDLK_KP_000
+pattern KeycodeThousandsSeparator :: Keycode
 pattern KeycodeThousandsSeparator = Keycode Raw.SDLK_THOUSANDSSEPARATOR
+pattern KeycodeDecimalSeparator :: Keycode
 pattern KeycodeDecimalSeparator = Keycode Raw.SDLK_DECIMALSEPARATOR
+pattern KeycodeCurrencyUnit :: Keycode
 pattern KeycodeCurrencyUnit = Keycode Raw.SDLK_CURRENCYUNIT
+pattern KeycodeCurrencySubunit :: Keycode
 pattern KeycodeCurrencySubunit = Keycode Raw.SDLK_CURRENCYSUBUNIT
+pattern KeycodeKPLeftParen :: Keycode
 pattern KeycodeKPLeftParen = Keycode Raw.SDLK_KP_LEFTPAREN
+pattern KeycodeKPRightParen :: Keycode
 pattern KeycodeKPRightParen = Keycode Raw.SDLK_KP_RIGHTPAREN
+pattern KeycodeKPLeftBrace :: Keycode
 pattern KeycodeKPLeftBrace = Keycode Raw.SDLK_KP_LEFTBRACE
+pattern KeycodeKPRightBrace :: Keycode
 pattern KeycodeKPRightBrace = Keycode Raw.SDLK_KP_RIGHTBRACE
+pattern KeycodeKPTab :: Keycode
 pattern KeycodeKPTab = Keycode Raw.SDLK_KP_TAB
+pattern KeycodeKPBackspace :: Keycode
 pattern KeycodeKPBackspace = Keycode Raw.SDLK_KP_BACKSPACE
+pattern KeycodeKPA :: Keycode
 pattern KeycodeKPA = Keycode Raw.SDLK_KP_A
+pattern KeycodeKPB :: Keycode
 pattern KeycodeKPB = Keycode Raw.SDLK_KP_B
+pattern KeycodeKPC :: Keycode
 pattern KeycodeKPC = Keycode Raw.SDLK_KP_C
+pattern KeycodeKPD :: Keycode
 pattern KeycodeKPD = Keycode Raw.SDLK_KP_D
+pattern KeycodeKPE :: Keycode
 pattern KeycodeKPE = Keycode Raw.SDLK_KP_E
+pattern KeycodeKPF :: Keycode
 pattern KeycodeKPF = Keycode Raw.SDLK_KP_F
+pattern KeycodeKPXor :: Keycode
 pattern KeycodeKPXor = Keycode Raw.SDLK_KP_XOR
+pattern KeycodeKPPower :: Keycode
 pattern KeycodeKPPower = Keycode Raw.SDLK_KP_POWER
+pattern KeycodeKPPercent :: Keycode
 pattern KeycodeKPPercent = Keycode Raw.SDLK_KP_PERCENT
+pattern KeycodeKPLess :: Keycode
 pattern KeycodeKPLess = Keycode Raw.SDLK_KP_LESS
+pattern KeycodeKPGreater :: Keycode
 pattern KeycodeKPGreater = Keycode Raw.SDLK_KP_GREATER
+pattern KeycodeKPAmpersand :: Keycode
 pattern KeycodeKPAmpersand = Keycode Raw.SDLK_KP_AMPERSAND
+pattern KeycodeKPDblAmpersand :: Keycode
 pattern KeycodeKPDblAmpersand = Keycode Raw.SDLK_KP_DBLAMPERSAND
+pattern KeycodeKPVerticalBar :: Keycode
 pattern KeycodeKPVerticalBar = Keycode Raw.SDLK_KP_VERTICALBAR
+pattern KeycodeKPDblVerticalBar :: Keycode
 pattern KeycodeKPDblVerticalBar = Keycode Raw.SDLK_KP_DBLVERTICALBAR
+pattern KeycodeKPColon :: Keycode
 pattern KeycodeKPColon = Keycode Raw.SDLK_KP_COLON
+pattern KeycodeKPHash :: Keycode
 pattern KeycodeKPHash = Keycode Raw.SDLK_KP_HASH
+pattern KeycodeKPSpace :: Keycode
 pattern KeycodeKPSpace = Keycode Raw.SDLK_KP_SPACE
+pattern KeycodeKPAt :: Keycode
 pattern KeycodeKPAt = Keycode Raw.SDLK_KP_AT
+pattern KeycodeKPExclam :: Keycode
 pattern KeycodeKPExclam = Keycode Raw.SDLK_KP_EXCLAM
+pattern KeycodeKPMemStore :: Keycode
 pattern KeycodeKPMemStore = Keycode Raw.SDLK_KP_MEMSTORE
+pattern KeycodeKPMemRecall :: Keycode
 pattern KeycodeKPMemRecall = Keycode Raw.SDLK_KP_MEMRECALL
+pattern KeycodeKPMemClear :: Keycode
 pattern KeycodeKPMemClear = Keycode Raw.SDLK_KP_MEMCLEAR
+pattern KeycodeKPMemAdd :: Keycode
 pattern KeycodeKPMemAdd = Keycode Raw.SDLK_KP_MEMADD
+pattern KeycodeKPMemSubtract :: Keycode
 pattern KeycodeKPMemSubtract = Keycode Raw.SDLK_KP_MEMSUBTRACT
+pattern KeycodeKPMemMultiply :: Keycode
 pattern KeycodeKPMemMultiply = Keycode Raw.SDLK_KP_MEMMULTIPLY
+pattern KeycodeKPMemDivide :: Keycode
 pattern KeycodeKPMemDivide = Keycode Raw.SDLK_KP_MEMDIVIDE
+pattern KeycodeKPPlusMinus :: Keycode
 pattern KeycodeKPPlusMinus = Keycode Raw.SDLK_KP_PLUSMINUS
+pattern KeycodeKPClear :: Keycode
 pattern KeycodeKPClear = Keycode Raw.SDLK_KP_CLEAR
+pattern KeycodeKPClearEntry :: Keycode
 pattern KeycodeKPClearEntry = Keycode Raw.SDLK_KP_CLEARENTRY
+pattern KeycodeKPBinary :: Keycode
 pattern KeycodeKPBinary = Keycode Raw.SDLK_KP_BINARY
+pattern KeycodeKPOctal :: Keycode
 pattern KeycodeKPOctal = Keycode Raw.SDLK_KP_OCTAL
+pattern KeycodeKPDecimal :: Keycode
 pattern KeycodeKPDecimal = Keycode Raw.SDLK_KP_DECIMAL
+pattern KeycodeKPHexadecimal :: Keycode
 pattern KeycodeKPHexadecimal = Keycode Raw.SDLK_KP_HEXADECIMAL
+pattern KeycodeLCtrl :: Keycode
 pattern KeycodeLCtrl = Keycode Raw.SDLK_LCTRL
+pattern KeycodeLShift :: Keycode
 pattern KeycodeLShift = Keycode Raw.SDLK_LSHIFT
+pattern KeycodeLAlt :: Keycode
 pattern KeycodeLAlt = Keycode Raw.SDLK_LALT
+pattern KeycodeLGUI :: Keycode
 pattern KeycodeLGUI = Keycode Raw.SDLK_LGUI
+pattern KeycodeRCtrl :: Keycode
 pattern KeycodeRCtrl = Keycode Raw.SDLK_RCTRL
+pattern KeycodeRShift :: Keycode
 pattern KeycodeRShift = Keycode Raw.SDLK_RSHIFT
+pattern KeycodeRAlt :: Keycode
 pattern KeycodeRAlt = Keycode Raw.SDLK_RALT
+pattern KeycodeRGUI :: Keycode
 pattern KeycodeRGUI = Keycode Raw.SDLK_RGUI
+pattern KeycodeMode :: Keycode
 pattern KeycodeMode = Keycode Raw.SDLK_MODE
+pattern KeycodeAudioNext :: Keycode
 pattern KeycodeAudioNext = Keycode Raw.SDLK_AUDIONEXT
+pattern KeycodeAudioPrev :: Keycode
 pattern KeycodeAudioPrev = Keycode Raw.SDLK_AUDIOPREV
+pattern KeycodeAudioStop :: Keycode
 pattern KeycodeAudioStop = Keycode Raw.SDLK_AUDIOSTOP
+pattern KeycodeAudioPlay :: Keycode
 pattern KeycodeAudioPlay = Keycode Raw.SDLK_AUDIOPLAY
+pattern KeycodeAudioMute :: Keycode
 pattern KeycodeAudioMute = Keycode Raw.SDLK_AUDIOMUTE
+pattern KeycodeMediaSelect :: Keycode
 pattern KeycodeMediaSelect = Keycode Raw.SDLK_MEDIASELECT
+pattern KeycodeWWW :: Keycode
 pattern KeycodeWWW = Keycode Raw.SDLK_WWW
+pattern KeycodeMail :: Keycode
 pattern KeycodeMail = Keycode Raw.SDLK_MAIL
+pattern KeycodeCalculator :: Keycode
 pattern KeycodeCalculator = Keycode Raw.SDLK_CALCULATOR
+pattern KeycodeComputer :: Keycode
 pattern KeycodeComputer = Keycode Raw.SDLK_COMPUTER
+pattern KeycodeACSearch :: Keycode
 pattern KeycodeACSearch = Keycode Raw.SDLK_AC_SEARCH
+pattern KeycodeACHome :: Keycode
 pattern KeycodeACHome = Keycode Raw.SDLK_AC_HOME
+pattern KeycodeACBack :: Keycode
 pattern KeycodeACBack = Keycode Raw.SDLK_AC_BACK
+pattern KeycodeACForward :: Keycode
 pattern KeycodeACForward = Keycode Raw.SDLK_AC_FORWARD
+pattern KeycodeACStop :: Keycode
 pattern KeycodeACStop = Keycode Raw.SDLK_AC_STOP
+pattern KeycodeACRefresh :: Keycode
 pattern KeycodeACRefresh = Keycode Raw.SDLK_AC_REFRESH
+pattern KeycodeACBookmarks :: Keycode
 pattern KeycodeACBookmarks = Keycode Raw.SDLK_AC_BOOKMARKS
+pattern KeycodeBrightnessDown :: Keycode
 pattern KeycodeBrightnessDown = Keycode Raw.SDLK_BRIGHTNESSDOWN
+pattern KeycodeBrightnessUp :: Keycode
 pattern KeycodeBrightnessUp = Keycode Raw.SDLK_BRIGHTNESSUP
+pattern KeycodeDisplaySwitch :: Keycode
 pattern KeycodeDisplaySwitch = Keycode Raw.SDLK_DISPLAYSWITCH
+pattern KeycodeKbdIllumToggle :: Keycode
 pattern KeycodeKbdIllumToggle = Keycode Raw.SDLK_KBDILLUMTOGGLE
+pattern KeycodeKbdIllumDown :: Keycode
 pattern KeycodeKbdIllumDown = Keycode Raw.SDLK_KBDILLUMDOWN
+pattern KeycodeKbdIllumUp :: Keycode
 pattern KeycodeKbdIllumUp = Keycode Raw.SDLK_KBDILLUMUP
+pattern KeycodeEject :: Keycode
 pattern KeycodeEject = Keycode Raw.SDLK_EJECT
+pattern KeycodeSleep :: Keycode
 pattern KeycodeSleep = Keycode Raw.SDLK_SLEEP
 
 instance FromNumber Keycode Int32 where

--- a/src/SDL/Input/Mouse.hs
+++ b/src/SDL/Input/Mouse.hs
@@ -74,7 +74,7 @@ data LocationMode = AbsoluteLocation | RelativeLocation deriving Eq
 -- When relative mouse mode is enabled, cursor is hidden and mouse position
 -- will not change. However, you will be delivered relative mouse position
 -- change events.
-setMouseLocationMode :: (Functor m, MonadIO m) => LocationMode -> m LocationMode
+setMouseLocationMode :: MonadIO m => LocationMode -> m LocationMode
 setMouseLocationMode mode =
   Raw.setRelativeMouseMode (mode == RelativeLocation) >> getMouseLocationMode
 
@@ -94,7 +94,7 @@ getModalMouseLocation = do
   return (mode, location)
 
 -- deprecated
-setRelativeMouseMode :: (Functor m, MonadIO m) => Bool -> m ()
+setRelativeMouseMode :: MonadIO m => Bool -> m ()
 {-# DEPRECATED setRelativeMouseMode "Use setMouseLocationMode instead" #-}
 setRelativeMouseMode enable =
   throwIfNeg_ "SDL.Input.Mouse" "SDL_SetRelativeMouseMode" $
@@ -152,11 +152,11 @@ cursorVisible :: StateVar Bool
 cursorVisible = makeStateVar getCursorVisible setCursorVisible
   where
   -- The usage of 'void' is OK here - Raw.showCursor just returns the old state.
-  setCursorVisible :: (Functor m, MonadIO m) => Bool -> m ()
+  setCursorVisible :: MonadIO m => Bool -> m ()
   setCursorVisible True = void $ Raw.showCursor 1
   setCursorVisible False = void $ Raw.showCursor 0
 
-  getCursorVisible :: (Functor m, MonadIO m) => m Bool
+  getCursorVisible :: MonadIO m => m Bool
   getCursorVisible = (== 1) <$> Raw.showCursor (-1)
 
 -- | Retrieve the current location of the mouse, relative to the currently focused window.

--- a/src/SDL/Internal/Numbered.hs
+++ b/src/SDL/Internal/Numbered.hs
@@ -4,8 +4,8 @@ module SDL.Internal.Numbered
   , ToNumber(..)
   ) where
 
-class (Integral b) => FromNumber a b | a -> b where
+class Integral b => FromNumber a b | a -> b where
   fromNumber :: b -> a
 
-class (Integral b) => ToNumber a b | a -> b where
+class Integral b => ToNumber a b | a -> b where
   toNumber :: a -> b

--- a/src/SDL/Power.hs
+++ b/src/SDL/Power.hs
@@ -28,7 +28,7 @@ import qualified SDL.Raw as Raw
 -- Throws 'SDLException' if the current power state can not be determined.
 --
 -- See @<https://wiki.libsdl.org/SDL_GetPowerInfo SDL_GetPowerInfo>@ for C documentation.
-getPowerInfo :: (Functor m, MonadIO m) => m PowerState
+getPowerInfo :: MonadIO m => m PowerState
 getPowerInfo =
   liftIO $
   alloca $ \secsPtr ->

--- a/src/SDL/Raw/Enum.hsc
+++ b/src/SDL/Raw/Enum.hsc
@@ -908,820 +908,1601 @@ type Scancode = (#type SDL_Scancode)
 type SystemCursor = (#type SDL_SystemCursor)
 type ThreadPriority = (#type SDL_ThreadPriority)
 
-pattern SDL_AUDIO_S8 = (#const AUDIO_S8) :: AudioFormat
-pattern SDL_AUDIO_U8 = (#const AUDIO_U8) :: AudioFormat
-pattern SDL_AUDIO_S16LSB = (#const AUDIO_S16LSB) :: AudioFormat
-pattern SDL_AUDIO_S16MSB = (#const AUDIO_S16MSB) :: AudioFormat
-pattern SDL_AUDIO_S16SYS = (#const AUDIO_S16SYS) :: AudioFormat
-pattern SDL_AUDIO_U16LSB = (#const AUDIO_U16LSB) :: AudioFormat
-pattern SDL_AUDIO_U16MSB = (#const AUDIO_U16MSB) :: AudioFormat
-pattern SDL_AUDIO_U16SYS = (#const AUDIO_U16SYS) :: AudioFormat
-pattern SDL_AUDIO_S32LSB = (#const AUDIO_S32LSB) :: AudioFormat
-pattern SDL_AUDIO_S32MSB = (#const AUDIO_S32MSB) :: AudioFormat
-pattern SDL_AUDIO_S32SYS = (#const AUDIO_S32SYS) :: AudioFormat
-pattern SDL_AUDIO_F32LSB = (#const AUDIO_F32LSB) :: AudioFormat
-pattern SDL_AUDIO_F32MSB = (#const AUDIO_F32MSB) :: AudioFormat
-pattern SDL_AUDIO_F32SYS = (#const AUDIO_F32SYS) :: AudioFormat
+pattern SDL_AUDIO_S8 :: AudioFormat
+pattern SDL_AUDIO_S8 = (#const AUDIO_S8)
+pattern SDL_AUDIO_U8 :: AudioFormat
+pattern SDL_AUDIO_U8 = (#const AUDIO_U8)
+pattern SDL_AUDIO_S16LSB :: AudioFormat
+pattern SDL_AUDIO_S16LSB = (#const AUDIO_S16LSB)
+pattern SDL_AUDIO_S16MSB :: AudioFormat
+pattern SDL_AUDIO_S16MSB = (#const AUDIO_S16MSB)
+pattern SDL_AUDIO_S16SYS :: AudioFormat
+pattern SDL_AUDIO_S16SYS = (#const AUDIO_S16SYS)
+pattern SDL_AUDIO_U16LSB :: AudioFormat
+pattern SDL_AUDIO_U16LSB = (#const AUDIO_U16LSB)
+pattern SDL_AUDIO_U16MSB :: AudioFormat
+pattern SDL_AUDIO_U16MSB = (#const AUDIO_U16MSB)
+pattern SDL_AUDIO_U16SYS :: AudioFormat
+pattern SDL_AUDIO_U16SYS = (#const AUDIO_U16SYS)
+pattern SDL_AUDIO_S32LSB :: AudioFormat
+pattern SDL_AUDIO_S32LSB = (#const AUDIO_S32LSB)
+pattern SDL_AUDIO_S32MSB :: AudioFormat
+pattern SDL_AUDIO_S32MSB = (#const AUDIO_S32MSB)
+pattern SDL_AUDIO_S32SYS :: AudioFormat
+pattern SDL_AUDIO_S32SYS = (#const AUDIO_S32SYS)
+pattern SDL_AUDIO_F32LSB :: AudioFormat
+pattern SDL_AUDIO_F32LSB = (#const AUDIO_F32LSB)
+pattern SDL_AUDIO_F32MSB :: AudioFormat
+pattern SDL_AUDIO_F32MSB = (#const AUDIO_F32MSB)
+pattern SDL_AUDIO_F32SYS :: AudioFormat
+pattern SDL_AUDIO_F32SYS = (#const AUDIO_F32SYS)
 
+pattern SDL_AUDIO_STOPPED :: AudioStatus
 pattern SDL_AUDIO_STOPPED = (#const SDL_AUDIO_STOPPED) :: AudioStatus
+pattern SDL_AUDIO_PLAYING :: AudioStatus
 pattern SDL_AUDIO_PLAYING = (#const SDL_AUDIO_PLAYING) :: AudioStatus
+pattern SDL_AUDIO_PAUSED :: AudioStatus
 pattern SDL_AUDIO_PAUSED = (#const SDL_AUDIO_PAUSED) :: AudioStatus
 
+pattern SDL_BLENDMODE_NONE :: BlendMode
 pattern SDL_BLENDMODE_NONE = (#const SDL_BLENDMODE_NONE) :: BlendMode
+pattern SDL_BLENDMODE_BLEND :: BlendMode
 pattern SDL_BLENDMODE_BLEND = (#const SDL_BLENDMODE_BLEND) :: BlendMode
+pattern SDL_BLENDMODE_ADD :: BlendMode
 pattern SDL_BLENDMODE_ADD = (#const SDL_BLENDMODE_ADD) :: BlendMode
+pattern SDL_BLENDMODE_MOD :: BlendMode
 pattern SDL_BLENDMODE_MOD = (#const SDL_BLENDMODE_MOD) :: BlendMode
 
+pattern SDL_BYTEORDER :: Endian
 pattern SDL_BYTEORDER = (#const SDL_BYTEORDER) :: Endian
+pattern SDL_LIL_ENDIAN :: Endian
 pattern SDL_LIL_ENDIAN = (#const SDL_LIL_ENDIAN) :: Endian
+pattern SDL_BIG_ENDIAN :: Endian
 pattern SDL_BIG_ENDIAN = (#const SDL_BIG_ENDIAN) :: Endian
 
+pattern SDL_ADDEVENT :: EventAction
 pattern SDL_ADDEVENT = (#const SDL_ADDEVENT) :: EventAction
+pattern SDL_PEEKEVENT :: EventAction
 pattern SDL_PEEKEVENT = (#const SDL_PEEKEVENT) :: EventAction
+pattern SDL_GETEVENT :: EventAction
 pattern SDL_GETEVENT = (#const SDL_GETEVENT) :: EventAction
 
+pattern SDL_CONTROLLER_AXIS_INVALID :: GameControllerAxis
 pattern SDL_CONTROLLER_AXIS_INVALID = (#const SDL_CONTROLLER_AXIS_INVALID) :: GameControllerAxis
+pattern SDL_CONTROLLER_AXIS_LEFTX :: GameControllerAxis
 pattern SDL_CONTROLLER_AXIS_LEFTX = (#const SDL_CONTROLLER_AXIS_LEFTX) :: GameControllerAxis
+pattern SDL_CONTROLLER_AXIS_LEFTY :: GameControllerAxis
 pattern SDL_CONTROLLER_AXIS_LEFTY = (#const SDL_CONTROLLER_AXIS_LEFTY) :: GameControllerAxis
+pattern SDL_CONTROLLER_AXIS_RIGHTX :: GameControllerAxis
 pattern SDL_CONTROLLER_AXIS_RIGHTX = (#const SDL_CONTROLLER_AXIS_RIGHTX) :: GameControllerAxis
+pattern SDL_CONTROLLER_AXIS_RIGHTY :: GameControllerAxis
 pattern SDL_CONTROLLER_AXIS_RIGHTY = (#const SDL_CONTROLLER_AXIS_RIGHTY) :: GameControllerAxis
+pattern SDL_CONTROLLER_AXIS_TRIGGERLEFT :: GameControllerAxis
 pattern SDL_CONTROLLER_AXIS_TRIGGERLEFT = (#const SDL_CONTROLLER_AXIS_TRIGGERLEFT) :: GameControllerAxis
+pattern SDL_CONTROLLER_AXIS_TRIGGERRIGHT :: GameControllerAxis
 pattern SDL_CONTROLLER_AXIS_TRIGGERRIGHT = (#const SDL_CONTROLLER_AXIS_TRIGGERRIGHT) :: GameControllerAxis
+pattern SDL_CONTROLLER_AXIS_MAX :: GameControllerAxis
 pattern SDL_CONTROLLER_AXIS_MAX = (#const SDL_CONTROLLER_AXIS_MAX) :: GameControllerAxis
 
+pattern SDL_CONTROLLER_BUTTON_INVALID :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_INVALID = (#const SDL_CONTROLLER_BUTTON_INVALID) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_A :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_A = (#const SDL_CONTROLLER_BUTTON_A) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_B :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_B = (#const SDL_CONTROLLER_BUTTON_B) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_X :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_X = (#const SDL_CONTROLLER_BUTTON_X) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_Y :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_Y = (#const SDL_CONTROLLER_BUTTON_Y) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_BACK :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_BACK = (#const SDL_CONTROLLER_BUTTON_BACK) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_GUIDE :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_GUIDE = (#const SDL_CONTROLLER_BUTTON_GUIDE) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_START :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_START = (#const SDL_CONTROLLER_BUTTON_START) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_LEFTSTICK :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_LEFTSTICK = (#const SDL_CONTROLLER_BUTTON_LEFTSTICK) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_RIGHTSTICK :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_RIGHTSTICK = (#const SDL_CONTROLLER_BUTTON_RIGHTSTICK) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_LEFTSHOULDER :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_LEFTSHOULDER = (#const SDL_CONTROLLER_BUTTON_LEFTSHOULDER) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_RIGHTSHOULDER :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_RIGHTSHOULDER = (#const SDL_CONTROLLER_BUTTON_RIGHTSHOULDER) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_DPAD_UP :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_DPAD_UP = (#const SDL_CONTROLLER_BUTTON_DPAD_UP) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_DPAD_DOWN :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_DPAD_DOWN = (#const SDL_CONTROLLER_BUTTON_DPAD_DOWN) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_DPAD_LEFT :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_DPAD_LEFT = (#const SDL_CONTROLLER_BUTTON_DPAD_LEFT) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_DPAD_RIGHT :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_DPAD_RIGHT = (#const SDL_CONTROLLER_BUTTON_DPAD_RIGHT) :: GameControllerButton
+pattern SDL_CONTROLLER_BUTTON_MAX :: GameControllerButton
 pattern SDL_CONTROLLER_BUTTON_MAX = (#const SDL_CONTROLLER_BUTTON_MAX) :: GameControllerButton
 
+pattern SDL_GL_RED_SIZE :: GLattr
 pattern SDL_GL_RED_SIZE = (#const SDL_GL_RED_SIZE) :: GLattr
+pattern SDL_GL_GREEN_SIZE :: GLattr
 pattern SDL_GL_GREEN_SIZE = (#const SDL_GL_GREEN_SIZE) :: GLattr
+pattern SDL_GL_BLUE_SIZE :: GLattr
 pattern SDL_GL_BLUE_SIZE = (#const SDL_GL_BLUE_SIZE) :: GLattr
+pattern SDL_GL_ALPHA_SIZE :: GLattr
 pattern SDL_GL_ALPHA_SIZE = (#const SDL_GL_ALPHA_SIZE) :: GLattr
+pattern SDL_GL_BUFFER_SIZE :: GLattr
 pattern SDL_GL_BUFFER_SIZE = (#const SDL_GL_BUFFER_SIZE) :: GLattr
+pattern SDL_GL_DOUBLEBUFFER :: GLattr
 pattern SDL_GL_DOUBLEBUFFER = (#const SDL_GL_DOUBLEBUFFER) :: GLattr
+pattern SDL_GL_DEPTH_SIZE :: GLattr
 pattern SDL_GL_DEPTH_SIZE = (#const SDL_GL_DEPTH_SIZE) :: GLattr
+pattern SDL_GL_STENCIL_SIZE :: GLattr
 pattern SDL_GL_STENCIL_SIZE = (#const SDL_GL_STENCIL_SIZE) :: GLattr
+pattern SDL_GL_ACCUM_RED_SIZE :: GLattr
 pattern SDL_GL_ACCUM_RED_SIZE = (#const SDL_GL_ACCUM_RED_SIZE) :: GLattr
+pattern SDL_GL_ACCUM_GREEN_SIZE :: GLattr
 pattern SDL_GL_ACCUM_GREEN_SIZE = (#const SDL_GL_ACCUM_GREEN_SIZE) :: GLattr
+pattern SDL_GL_ACCUM_BLUE_SIZE :: GLattr
 pattern SDL_GL_ACCUM_BLUE_SIZE = (#const SDL_GL_ACCUM_BLUE_SIZE) :: GLattr
+pattern SDL_GL_ACCUM_ALPHA_SIZE :: GLattr
 pattern SDL_GL_ACCUM_ALPHA_SIZE = (#const SDL_GL_ACCUM_ALPHA_SIZE) :: GLattr
+pattern SDL_GL_STEREO :: GLattr
 pattern SDL_GL_STEREO = (#const SDL_GL_STEREO) :: GLattr
+pattern SDL_GL_MULTISAMPLEBUFFERS :: GLattr
 pattern SDL_GL_MULTISAMPLEBUFFERS = (#const SDL_GL_MULTISAMPLEBUFFERS) :: GLattr
+pattern SDL_GL_MULTISAMPLESAMPLES :: GLattr
 pattern SDL_GL_MULTISAMPLESAMPLES = (#const SDL_GL_MULTISAMPLESAMPLES) :: GLattr
+pattern SDL_GL_ACCELERATED_VISUAL :: GLattr
 pattern SDL_GL_ACCELERATED_VISUAL = (#const SDL_GL_ACCELERATED_VISUAL) :: GLattr
+pattern SDL_GL_RETAINED_BACKING :: GLattr
 pattern SDL_GL_RETAINED_BACKING = (#const SDL_GL_RETAINED_BACKING) :: GLattr
+pattern SDL_GL_CONTEXT_MAJOR_VERSION :: GLattr
 pattern SDL_GL_CONTEXT_MAJOR_VERSION = (#const SDL_GL_CONTEXT_MAJOR_VERSION) :: GLattr
+pattern SDL_GL_CONTEXT_MINOR_VERSION :: GLattr
 pattern SDL_GL_CONTEXT_MINOR_VERSION = (#const SDL_GL_CONTEXT_MINOR_VERSION) :: GLattr
+pattern SDL_GL_CONTEXT_EGL :: GLattr
 pattern SDL_GL_CONTEXT_EGL = (#const SDL_GL_CONTEXT_EGL) :: GLattr
+pattern SDL_GL_CONTEXT_FLAGS :: GLattr
 pattern SDL_GL_CONTEXT_FLAGS = (#const SDL_GL_CONTEXT_FLAGS) :: GLattr
+pattern SDL_GL_CONTEXT_PROFILE_MASK :: GLattr
 pattern SDL_GL_CONTEXT_PROFILE_MASK = (#const SDL_GL_CONTEXT_PROFILE_MASK) :: GLattr
+pattern SDL_GL_SHARE_WITH_CURRENT_CONTEXT :: GLattr
 pattern SDL_GL_SHARE_WITH_CURRENT_CONTEXT = (#const SDL_GL_SHARE_WITH_CURRENT_CONTEXT) :: GLattr
+pattern SDL_GL_FRAMEBUFFER_SRGB_CAPABLE :: GLattr
 pattern SDL_GL_FRAMEBUFFER_SRGB_CAPABLE = (#const SDL_GL_FRAMEBUFFER_SRGB_CAPABLE) :: GLattr
 
+pattern SDL_HINT_DEFAULT :: HintPriority
 pattern SDL_HINT_DEFAULT = (#const SDL_HINT_DEFAULT) :: HintPriority
+pattern SDL_HINT_NORMAL :: HintPriority
 pattern SDL_HINT_NORMAL = (#const SDL_HINT_NORMAL) :: HintPriority
+pattern SDL_HINT_OVERRIDE :: HintPriority
 pattern SDL_HINT_OVERRIDE = (#const SDL_HINT_OVERRIDE) :: HintPriority
 
+pattern SDL_INIT_TIMER :: InitFlag
 pattern SDL_INIT_TIMER = (#const SDL_INIT_TIMER) :: InitFlag
+pattern SDL_INIT_AUDIO :: InitFlag
 pattern SDL_INIT_AUDIO = (#const SDL_INIT_AUDIO) :: InitFlag
+pattern SDL_INIT_VIDEO :: InitFlag
 pattern SDL_INIT_VIDEO = (#const SDL_INIT_VIDEO) :: InitFlag
+pattern SDL_INIT_JOYSTICK :: InitFlag
 pattern SDL_INIT_JOYSTICK = (#const SDL_INIT_JOYSTICK) :: InitFlag
+pattern SDL_INIT_HAPTIC :: InitFlag
 pattern SDL_INIT_HAPTIC = (#const SDL_INIT_HAPTIC) :: InitFlag
+pattern SDL_INIT_GAMECONTROLLER :: InitFlag
 pattern SDL_INIT_GAMECONTROLLER = (#const SDL_INIT_GAMECONTROLLER) :: InitFlag
+pattern SDL_INIT_EVENTS :: InitFlag
 pattern SDL_INIT_EVENTS = (#const SDL_INIT_EVENTS) :: InitFlag
+pattern SDL_INIT_NOPARACHUTE :: InitFlag
 pattern SDL_INIT_NOPARACHUTE = (#const SDL_INIT_NOPARACHUTE) :: InitFlag
+pattern SDL_INIT_EVERYTHING :: InitFlag
 pattern SDL_INIT_EVERYTHING = (#const SDL_INIT_EVERYTHING) :: InitFlag
 
+pattern SDLK_UNKNOWN :: Keycode
 pattern SDLK_UNKNOWN = (#const SDLK_UNKNOWN) :: Keycode
+pattern SDLK_RETURN :: Keycode
 pattern SDLK_RETURN = (#const SDLK_RETURN) :: Keycode
+pattern SDLK_ESCAPE :: Keycode
 pattern SDLK_ESCAPE = (#const SDLK_ESCAPE) :: Keycode
+pattern SDLK_BACKSPACE :: Keycode
 pattern SDLK_BACKSPACE = (#const SDLK_BACKSPACE) :: Keycode
+pattern SDLK_TAB :: Keycode
 pattern SDLK_TAB = (#const SDLK_TAB) :: Keycode
+pattern SDLK_SPACE :: Keycode
 pattern SDLK_SPACE = (#const SDLK_SPACE) :: Keycode
+pattern SDLK_EXCLAIM :: Keycode
 pattern SDLK_EXCLAIM = (#const SDLK_EXCLAIM) :: Keycode
+pattern SDLK_QUOTEDBL :: Keycode
 pattern SDLK_QUOTEDBL = (#const SDLK_QUOTEDBL) :: Keycode
+pattern SDLK_HASH :: Keycode
 pattern SDLK_HASH = (#const SDLK_HASH) :: Keycode
+pattern SDLK_PERCENT :: Keycode
 pattern SDLK_PERCENT = (#const SDLK_PERCENT) :: Keycode
+pattern SDLK_DOLLAR :: Keycode
 pattern SDLK_DOLLAR = (#const SDLK_DOLLAR) :: Keycode
+pattern SDLK_AMPERSAND :: Keycode
 pattern SDLK_AMPERSAND = (#const SDLK_AMPERSAND) :: Keycode
+pattern SDLK_QUOTE :: Keycode
 pattern SDLK_QUOTE = (#const SDLK_QUOTE) :: Keycode
+pattern SDLK_LEFTPAREN :: Keycode
 pattern SDLK_LEFTPAREN = (#const SDLK_LEFTPAREN) :: Keycode
+pattern SDLK_RIGHTPAREN :: Keycode
 pattern SDLK_RIGHTPAREN = (#const SDLK_RIGHTPAREN) :: Keycode
+pattern SDLK_ASTERISK :: Keycode
 pattern SDLK_ASTERISK = (#const SDLK_ASTERISK) :: Keycode
+pattern SDLK_PLUS :: Keycode
 pattern SDLK_PLUS = (#const SDLK_PLUS) :: Keycode
+pattern SDLK_COMMA :: Keycode
 pattern SDLK_COMMA = (#const SDLK_COMMA) :: Keycode
+pattern SDLK_MINUS :: Keycode
 pattern SDLK_MINUS = (#const SDLK_MINUS) :: Keycode
+pattern SDLK_PERIOD :: Keycode
 pattern SDLK_PERIOD = (#const SDLK_PERIOD) :: Keycode
+pattern SDLK_SLASH :: Keycode
 pattern SDLK_SLASH = (#const SDLK_SLASH) :: Keycode
+pattern SDLK_0 :: Keycode
 pattern SDLK_0 = (#const SDLK_0) :: Keycode
+pattern SDLK_1 :: Keycode
 pattern SDLK_1 = (#const SDLK_1) :: Keycode
+pattern SDLK_2 :: Keycode
 pattern SDLK_2 = (#const SDLK_2) :: Keycode
+pattern SDLK_3 :: Keycode
 pattern SDLK_3 = (#const SDLK_3) :: Keycode
+pattern SDLK_4 :: Keycode
 pattern SDLK_4 = (#const SDLK_4) :: Keycode
+pattern SDLK_5 :: Keycode
 pattern SDLK_5 = (#const SDLK_5) :: Keycode
+pattern SDLK_6 :: Keycode
 pattern SDLK_6 = (#const SDLK_6) :: Keycode
+pattern SDLK_7 :: Keycode
 pattern SDLK_7 = (#const SDLK_7) :: Keycode
+pattern SDLK_8 :: Keycode
 pattern SDLK_8 = (#const SDLK_8) :: Keycode
+pattern SDLK_9 :: Keycode
 pattern SDLK_9 = (#const SDLK_9) :: Keycode
+pattern SDLK_COLON :: Keycode
 pattern SDLK_COLON = (#const SDLK_COLON) :: Keycode
+pattern SDLK_SEMICOLON :: Keycode
 pattern SDLK_SEMICOLON = (#const SDLK_SEMICOLON) :: Keycode
+pattern SDLK_LESS :: Keycode
 pattern SDLK_LESS = (#const SDLK_LESS) :: Keycode
+pattern SDLK_EQUALS :: Keycode
 pattern SDLK_EQUALS = (#const SDLK_EQUALS) :: Keycode
+pattern SDLK_GREATER :: Keycode
 pattern SDLK_GREATER = (#const SDLK_GREATER) :: Keycode
+pattern SDLK_QUESTION :: Keycode
 pattern SDLK_QUESTION = (#const SDLK_QUESTION) :: Keycode
+pattern SDLK_AT :: Keycode
 pattern SDLK_AT = (#const SDLK_AT) :: Keycode
+pattern SDLK_LEFTBRACKET :: Keycode
 pattern SDLK_LEFTBRACKET = (#const SDLK_LEFTBRACKET) :: Keycode
+pattern SDLK_BACKSLASH :: Keycode
 pattern SDLK_BACKSLASH = (#const SDLK_BACKSLASH) :: Keycode
+pattern SDLK_RIGHTBRACKET :: Keycode
 pattern SDLK_RIGHTBRACKET = (#const SDLK_RIGHTBRACKET) :: Keycode
+pattern SDLK_CARET :: Keycode
 pattern SDLK_CARET = (#const SDLK_CARET) :: Keycode
+pattern SDLK_UNDERSCORE :: Keycode
 pattern SDLK_UNDERSCORE = (#const SDLK_UNDERSCORE) :: Keycode
+pattern SDLK_BACKQUOTE :: Keycode
 pattern SDLK_BACKQUOTE = (#const SDLK_BACKQUOTE) :: Keycode
+pattern SDLK_a :: Keycode
 pattern SDLK_a = (#const SDLK_a) :: Keycode
+pattern SDLK_b :: Keycode
 pattern SDLK_b = (#const SDLK_b) :: Keycode
+pattern SDLK_c :: Keycode
 pattern SDLK_c = (#const SDLK_c) :: Keycode
+pattern SDLK_d :: Keycode
 pattern SDLK_d = (#const SDLK_d) :: Keycode
+pattern SDLK_e :: Keycode
 pattern SDLK_e = (#const SDLK_e) :: Keycode
+pattern SDLK_f :: Keycode
 pattern SDLK_f = (#const SDLK_f) :: Keycode
+pattern SDLK_g :: Keycode
 pattern SDLK_g = (#const SDLK_g) :: Keycode
+pattern SDLK_h :: Keycode
 pattern SDLK_h = (#const SDLK_h) :: Keycode
+pattern SDLK_i :: Keycode
 pattern SDLK_i = (#const SDLK_i) :: Keycode
+pattern SDLK_j :: Keycode
 pattern SDLK_j = (#const SDLK_j) :: Keycode
+pattern SDLK_k :: Keycode
 pattern SDLK_k = (#const SDLK_k) :: Keycode
+pattern SDLK_l :: Keycode
 pattern SDLK_l = (#const SDLK_l) :: Keycode
+pattern SDLK_m :: Keycode
 pattern SDLK_m = (#const SDLK_m) :: Keycode
+pattern SDLK_n :: Keycode
 pattern SDLK_n = (#const SDLK_n) :: Keycode
+pattern SDLK_o :: Keycode
 pattern SDLK_o = (#const SDLK_o) :: Keycode
+pattern SDLK_p :: Keycode
 pattern SDLK_p = (#const SDLK_p) :: Keycode
+pattern SDLK_q :: Keycode
 pattern SDLK_q = (#const SDLK_q) :: Keycode
+pattern SDLK_r :: Keycode
 pattern SDLK_r = (#const SDLK_r) :: Keycode
+pattern SDLK_s :: Keycode
 pattern SDLK_s = (#const SDLK_s) :: Keycode
+pattern SDLK_t :: Keycode
 pattern SDLK_t = (#const SDLK_t) :: Keycode
+pattern SDLK_u :: Keycode
 pattern SDLK_u = (#const SDLK_u) :: Keycode
+pattern SDLK_v :: Keycode
 pattern SDLK_v = (#const SDLK_v) :: Keycode
+pattern SDLK_w :: Keycode
 pattern SDLK_w = (#const SDLK_w) :: Keycode
+pattern SDLK_x :: Keycode
 pattern SDLK_x = (#const SDLK_x) :: Keycode
+pattern SDLK_y :: Keycode
 pattern SDLK_y = (#const SDLK_y) :: Keycode
+pattern SDLK_z :: Keycode
 pattern SDLK_z = (#const SDLK_z) :: Keycode
+pattern SDLK_CAPSLOCK :: Keycode
 pattern SDLK_CAPSLOCK = (#const SDLK_CAPSLOCK) :: Keycode
+pattern SDLK_F1 :: Keycode
 pattern SDLK_F1 = (#const SDLK_F1) :: Keycode
+pattern SDLK_F2 :: Keycode
 pattern SDLK_F2 = (#const SDLK_F2) :: Keycode
+pattern SDLK_F3 :: Keycode
 pattern SDLK_F3 = (#const SDLK_F3) :: Keycode
+pattern SDLK_F4 :: Keycode
 pattern SDLK_F4 = (#const SDLK_F4) :: Keycode
+pattern SDLK_F5 :: Keycode
 pattern SDLK_F5 = (#const SDLK_F5) :: Keycode
+pattern SDLK_F6 :: Keycode
 pattern SDLK_F6 = (#const SDLK_F6) :: Keycode
+pattern SDLK_F7 :: Keycode
 pattern SDLK_F7 = (#const SDLK_F7) :: Keycode
+pattern SDLK_F8 :: Keycode
 pattern SDLK_F8 = (#const SDLK_F8) :: Keycode
+pattern SDLK_F9 :: Keycode
 pattern SDLK_F9 = (#const SDLK_F9) :: Keycode
+pattern SDLK_F10 :: Keycode
 pattern SDLK_F10 = (#const SDLK_F10) :: Keycode
+pattern SDLK_F11 :: Keycode
 pattern SDLK_F11 = (#const SDLK_F11) :: Keycode
+pattern SDLK_F12 :: Keycode
 pattern SDLK_F12 = (#const SDLK_F12) :: Keycode
+pattern SDLK_PRINTSCREEN :: Keycode
 pattern SDLK_PRINTSCREEN = (#const SDLK_PRINTSCREEN) :: Keycode
+pattern SDLK_SCROLLLOCK :: Keycode
 pattern SDLK_SCROLLLOCK = (#const SDLK_SCROLLLOCK) :: Keycode
+pattern SDLK_PAUSE :: Keycode
 pattern SDLK_PAUSE = (#const SDLK_PAUSE) :: Keycode
+pattern SDLK_INSERT :: Keycode
 pattern SDLK_INSERT = (#const SDLK_INSERT) :: Keycode
+pattern SDLK_HOME :: Keycode
 pattern SDLK_HOME = (#const SDLK_HOME) :: Keycode
+pattern SDLK_PAGEUP :: Keycode
 pattern SDLK_PAGEUP = (#const SDLK_PAGEUP) :: Keycode
+pattern SDLK_DELETE :: Keycode
 pattern SDLK_DELETE = (#const SDLK_DELETE) :: Keycode
+pattern SDLK_END :: Keycode
 pattern SDLK_END = (#const SDLK_END) :: Keycode
+pattern SDLK_PAGEDOWN :: Keycode
 pattern SDLK_PAGEDOWN = (#const SDLK_PAGEDOWN) :: Keycode
+pattern SDLK_RIGHT :: Keycode
 pattern SDLK_RIGHT = (#const SDLK_RIGHT) :: Keycode
+pattern SDLK_LEFT :: Keycode
 pattern SDLK_LEFT = (#const SDLK_LEFT) :: Keycode
+pattern SDLK_DOWN :: Keycode
 pattern SDLK_DOWN = (#const SDLK_DOWN) :: Keycode
+pattern SDLK_UP :: Keycode
 pattern SDLK_UP = (#const SDLK_UP) :: Keycode
+pattern SDLK_NUMLOCKCLEAR :: Keycode
 pattern SDLK_NUMLOCKCLEAR = (#const SDLK_NUMLOCKCLEAR) :: Keycode
+pattern SDLK_KP_DIVIDE :: Keycode
 pattern SDLK_KP_DIVIDE = (#const SDLK_KP_DIVIDE) :: Keycode
+pattern SDLK_KP_MULTIPLY :: Keycode
 pattern SDLK_KP_MULTIPLY = (#const SDLK_KP_MULTIPLY) :: Keycode
+pattern SDLK_KP_MINUS :: Keycode
 pattern SDLK_KP_MINUS = (#const SDLK_KP_MINUS) :: Keycode
+pattern SDLK_KP_PLUS :: Keycode
 pattern SDLK_KP_PLUS = (#const SDLK_KP_PLUS) :: Keycode
+pattern SDLK_KP_ENTER :: Keycode
 pattern SDLK_KP_ENTER = (#const SDLK_KP_ENTER) :: Keycode
+pattern SDLK_KP_1 :: Keycode
 pattern SDLK_KP_1 = (#const SDLK_KP_1) :: Keycode
+pattern SDLK_KP_2 :: Keycode
 pattern SDLK_KP_2 = (#const SDLK_KP_2) :: Keycode
+pattern SDLK_KP_3 :: Keycode
 pattern SDLK_KP_3 = (#const SDLK_KP_3) :: Keycode
+pattern SDLK_KP_4 :: Keycode
 pattern SDLK_KP_4 = (#const SDLK_KP_4) :: Keycode
+pattern SDLK_KP_5 :: Keycode
 pattern SDLK_KP_5 = (#const SDLK_KP_5) :: Keycode
+pattern SDLK_KP_6 :: Keycode
 pattern SDLK_KP_6 = (#const SDLK_KP_6) :: Keycode
+pattern SDLK_KP_7 :: Keycode
 pattern SDLK_KP_7 = (#const SDLK_KP_7) :: Keycode
+pattern SDLK_KP_8 :: Keycode
 pattern SDLK_KP_8 = (#const SDLK_KP_8) :: Keycode
+pattern SDLK_KP_9 :: Keycode
 pattern SDLK_KP_9 = (#const SDLK_KP_9) :: Keycode
+pattern SDLK_KP_0 :: Keycode
 pattern SDLK_KP_0 = (#const SDLK_KP_0) :: Keycode
+pattern SDLK_KP_PERIOD :: Keycode
 pattern SDLK_KP_PERIOD = (#const SDLK_KP_PERIOD) :: Keycode
+pattern SDLK_APPLICATION :: Keycode
 pattern SDLK_APPLICATION = (#const SDLK_APPLICATION) :: Keycode
+pattern SDLK_POWER :: Keycode
 pattern SDLK_POWER = (#const SDLK_POWER) :: Keycode
+pattern SDLK_KP_EQUALS :: Keycode
 pattern SDLK_KP_EQUALS = (#const SDLK_KP_EQUALS) :: Keycode
+pattern SDLK_F13 :: Keycode
 pattern SDLK_F13 = (#const SDLK_F13) :: Keycode
+pattern SDLK_F14 :: Keycode
 pattern SDLK_F14 = (#const SDLK_F14) :: Keycode
+pattern SDLK_F15 :: Keycode
 pattern SDLK_F15 = (#const SDLK_F15) :: Keycode
+pattern SDLK_F16 :: Keycode
 pattern SDLK_F16 = (#const SDLK_F16) :: Keycode
+pattern SDLK_F17 :: Keycode
 pattern SDLK_F17 = (#const SDLK_F17) :: Keycode
+pattern SDLK_F18 :: Keycode
 pattern SDLK_F18 = (#const SDLK_F18) :: Keycode
+pattern SDLK_F19 :: Keycode
 pattern SDLK_F19 = (#const SDLK_F19) :: Keycode
+pattern SDLK_F20 :: Keycode
 pattern SDLK_F20 = (#const SDLK_F20) :: Keycode
+pattern SDLK_F21 :: Keycode
 pattern SDLK_F21 = (#const SDLK_F21) :: Keycode
+pattern SDLK_F22 :: Keycode
 pattern SDLK_F22 = (#const SDLK_F22) :: Keycode
+pattern SDLK_F23 :: Keycode
 pattern SDLK_F23 = (#const SDLK_F23) :: Keycode
+pattern SDLK_F24 :: Keycode
 pattern SDLK_F24 = (#const SDLK_F24) :: Keycode
+pattern SDLK_EXECUTE :: Keycode
 pattern SDLK_EXECUTE = (#const SDLK_EXECUTE) :: Keycode
+pattern SDLK_HELP :: Keycode
 pattern SDLK_HELP = (#const SDLK_HELP) :: Keycode
+pattern SDLK_MENU :: Keycode
 pattern SDLK_MENU = (#const SDLK_MENU) :: Keycode
+pattern SDLK_SELECT :: Keycode
 pattern SDLK_SELECT = (#const SDLK_SELECT) :: Keycode
+pattern SDLK_STOP :: Keycode
 pattern SDLK_STOP = (#const SDLK_STOP) :: Keycode
+pattern SDLK_AGAIN :: Keycode
 pattern SDLK_AGAIN = (#const SDLK_AGAIN) :: Keycode
+pattern SDLK_UNDO :: Keycode
 pattern SDLK_UNDO = (#const SDLK_UNDO) :: Keycode
+pattern SDLK_CUT :: Keycode
 pattern SDLK_CUT = (#const SDLK_CUT) :: Keycode
+pattern SDLK_COPY :: Keycode
 pattern SDLK_COPY = (#const SDLK_COPY) :: Keycode
+pattern SDLK_PASTE :: Keycode
 pattern SDLK_PASTE = (#const SDLK_PASTE) :: Keycode
+pattern SDLK_FIND :: Keycode
 pattern SDLK_FIND = (#const SDLK_FIND) :: Keycode
+pattern SDLK_MUTE :: Keycode
 pattern SDLK_MUTE = (#const SDLK_MUTE) :: Keycode
+pattern SDLK_VOLUMEUP :: Keycode
 pattern SDLK_VOLUMEUP = (#const SDLK_VOLUMEUP) :: Keycode
+pattern SDLK_VOLUMEDOWN :: Keycode
 pattern SDLK_VOLUMEDOWN = (#const SDLK_VOLUMEDOWN) :: Keycode
+pattern SDLK_KP_COMMA :: Keycode
 pattern SDLK_KP_COMMA = (#const SDLK_KP_COMMA) :: Keycode
+pattern SDLK_KP_EQUALSAS400 :: Keycode
 pattern SDLK_KP_EQUALSAS400 = (#const SDLK_KP_EQUALSAS400) :: Keycode
+pattern SDLK_ALTERASE :: Keycode
 pattern SDLK_ALTERASE = (#const SDLK_ALTERASE) :: Keycode
+pattern SDLK_SYSREQ :: Keycode
 pattern SDLK_SYSREQ = (#const SDLK_SYSREQ) :: Keycode
+pattern SDLK_CANCEL :: Keycode
 pattern SDLK_CANCEL = (#const SDLK_CANCEL) :: Keycode
+pattern SDLK_CLEAR :: Keycode
 pattern SDLK_CLEAR = (#const SDLK_CLEAR) :: Keycode
+pattern SDLK_PRIOR :: Keycode
 pattern SDLK_PRIOR = (#const SDLK_PRIOR) :: Keycode
+pattern SDLK_RETURN2 :: Keycode
 pattern SDLK_RETURN2 = (#const SDLK_RETURN2) :: Keycode
+pattern SDLK_SEPARATOR :: Keycode
 pattern SDLK_SEPARATOR = (#const SDLK_SEPARATOR) :: Keycode
+pattern SDLK_OUT :: Keycode
 pattern SDLK_OUT = (#const SDLK_OUT) :: Keycode
+pattern SDLK_OPER :: Keycode
 pattern SDLK_OPER = (#const SDLK_OPER) :: Keycode
+pattern SDLK_CLEARAGAIN :: Keycode
 pattern SDLK_CLEARAGAIN = (#const SDLK_CLEARAGAIN) :: Keycode
+pattern SDLK_CRSEL :: Keycode
 pattern SDLK_CRSEL = (#const SDLK_CRSEL) :: Keycode
+pattern SDLK_EXSEL :: Keycode
 pattern SDLK_EXSEL = (#const SDLK_EXSEL) :: Keycode
+pattern SDLK_KP_00 :: Keycode
 pattern SDLK_KP_00 = (#const SDLK_KP_00) :: Keycode
+pattern SDLK_KP_000 :: Keycode
 pattern SDLK_KP_000 = (#const SDLK_KP_000) :: Keycode
+pattern SDLK_THOUSANDSSEPARATOR :: Keycode
 pattern SDLK_THOUSANDSSEPARATOR = (#const SDLK_THOUSANDSSEPARATOR) :: Keycode
+pattern SDLK_DECIMALSEPARATOR :: Keycode
 pattern SDLK_DECIMALSEPARATOR = (#const SDLK_DECIMALSEPARATOR) :: Keycode
+pattern SDLK_CURRENCYUNIT :: Keycode
 pattern SDLK_CURRENCYUNIT = (#const SDLK_CURRENCYUNIT) :: Keycode
+pattern SDLK_CURRENCYSUBUNIT :: Keycode
 pattern SDLK_CURRENCYSUBUNIT = (#const SDLK_CURRENCYSUBUNIT) :: Keycode
+pattern SDLK_KP_LEFTPAREN :: Keycode
 pattern SDLK_KP_LEFTPAREN = (#const SDLK_KP_LEFTPAREN) :: Keycode
+pattern SDLK_KP_RIGHTPAREN :: Keycode
 pattern SDLK_KP_RIGHTPAREN = (#const SDLK_KP_RIGHTPAREN) :: Keycode
+pattern SDLK_KP_LEFTBRACE :: Keycode
 pattern SDLK_KP_LEFTBRACE = (#const SDLK_KP_LEFTBRACE) :: Keycode
+pattern SDLK_KP_RIGHTBRACE :: Keycode
 pattern SDLK_KP_RIGHTBRACE = (#const SDLK_KP_RIGHTBRACE) :: Keycode
+pattern SDLK_KP_TAB :: Keycode
 pattern SDLK_KP_TAB = (#const SDLK_KP_TAB) :: Keycode
+pattern SDLK_KP_BACKSPACE :: Keycode
 pattern SDLK_KP_BACKSPACE = (#const SDLK_KP_BACKSPACE) :: Keycode
+pattern SDLK_KP_A :: Keycode
 pattern SDLK_KP_A = (#const SDLK_KP_A) :: Keycode
+pattern SDLK_KP_B :: Keycode
 pattern SDLK_KP_B = (#const SDLK_KP_B) :: Keycode
+pattern SDLK_KP_C :: Keycode
 pattern SDLK_KP_C = (#const SDLK_KP_C) :: Keycode
+pattern SDLK_KP_D :: Keycode
 pattern SDLK_KP_D = (#const SDLK_KP_D) :: Keycode
+pattern SDLK_KP_E :: Keycode
 pattern SDLK_KP_E = (#const SDLK_KP_E) :: Keycode
+pattern SDLK_KP_F :: Keycode
 pattern SDLK_KP_F = (#const SDLK_KP_F) :: Keycode
+pattern SDLK_KP_XOR :: Keycode
 pattern SDLK_KP_XOR = (#const SDLK_KP_XOR) :: Keycode
+pattern SDLK_KP_POWER :: Keycode
 pattern SDLK_KP_POWER = (#const SDLK_KP_POWER) :: Keycode
+pattern SDLK_KP_PERCENT :: Keycode
 pattern SDLK_KP_PERCENT = (#const SDLK_KP_PERCENT) :: Keycode
+pattern SDLK_KP_LESS :: Keycode
 pattern SDLK_KP_LESS = (#const SDLK_KP_LESS) :: Keycode
+pattern SDLK_KP_GREATER :: Keycode
 pattern SDLK_KP_GREATER = (#const SDLK_KP_GREATER) :: Keycode
+pattern SDLK_KP_AMPERSAND :: Keycode
 pattern SDLK_KP_AMPERSAND = (#const SDLK_KP_AMPERSAND) :: Keycode
+pattern SDLK_KP_DBLAMPERSAND :: Keycode
 pattern SDLK_KP_DBLAMPERSAND = (#const SDLK_KP_DBLAMPERSAND) :: Keycode
+pattern SDLK_KP_VERTICALBAR :: Keycode
 pattern SDLK_KP_VERTICALBAR = (#const SDLK_KP_VERTICALBAR) :: Keycode
+pattern SDLK_KP_DBLVERTICALBAR :: Keycode
 pattern SDLK_KP_DBLVERTICALBAR = (#const SDLK_KP_DBLVERTICALBAR) :: Keycode
+pattern SDLK_KP_COLON :: Keycode
 pattern SDLK_KP_COLON = (#const SDLK_KP_COLON) :: Keycode
+pattern SDLK_KP_HASH :: Keycode
 pattern SDLK_KP_HASH = (#const SDLK_KP_HASH) :: Keycode
+pattern SDLK_KP_SPACE :: Keycode
 pattern SDLK_KP_SPACE = (#const SDLK_KP_SPACE) :: Keycode
+pattern SDLK_KP_AT :: Keycode
 pattern SDLK_KP_AT = (#const SDLK_KP_AT) :: Keycode
+pattern SDLK_KP_EXCLAM :: Keycode
 pattern SDLK_KP_EXCLAM = (#const SDLK_KP_EXCLAM) :: Keycode
+pattern SDLK_KP_MEMSTORE :: Keycode
 pattern SDLK_KP_MEMSTORE = (#const SDLK_KP_MEMSTORE) :: Keycode
+pattern SDLK_KP_MEMRECALL :: Keycode
 pattern SDLK_KP_MEMRECALL = (#const SDLK_KP_MEMRECALL) :: Keycode
+pattern SDLK_KP_MEMCLEAR :: Keycode
 pattern SDLK_KP_MEMCLEAR = (#const SDLK_KP_MEMCLEAR) :: Keycode
+pattern SDLK_KP_MEMADD :: Keycode
 pattern SDLK_KP_MEMADD = (#const SDLK_KP_MEMADD) :: Keycode
+pattern SDLK_KP_MEMSUBTRACT :: Keycode
 pattern SDLK_KP_MEMSUBTRACT = (#const SDLK_KP_MEMSUBTRACT) :: Keycode
+pattern SDLK_KP_MEMMULTIPLY :: Keycode
 pattern SDLK_KP_MEMMULTIPLY = (#const SDLK_KP_MEMMULTIPLY) :: Keycode
+pattern SDLK_KP_MEMDIVIDE :: Keycode
 pattern SDLK_KP_MEMDIVIDE = (#const SDLK_KP_MEMDIVIDE) :: Keycode
+pattern SDLK_KP_PLUSMINUS :: Keycode
 pattern SDLK_KP_PLUSMINUS = (#const SDLK_KP_PLUSMINUS) :: Keycode
+pattern SDLK_KP_CLEAR :: Keycode
 pattern SDLK_KP_CLEAR = (#const SDLK_KP_CLEAR) :: Keycode
+pattern SDLK_KP_CLEARENTRY :: Keycode
 pattern SDLK_KP_CLEARENTRY = (#const SDLK_KP_CLEARENTRY) :: Keycode
+pattern SDLK_KP_BINARY :: Keycode
 pattern SDLK_KP_BINARY = (#const SDLK_KP_BINARY) :: Keycode
+pattern SDLK_KP_OCTAL :: Keycode
 pattern SDLK_KP_OCTAL = (#const SDLK_KP_OCTAL) :: Keycode
+pattern SDLK_KP_DECIMAL :: Keycode
 pattern SDLK_KP_DECIMAL = (#const SDLK_KP_DECIMAL) :: Keycode
+pattern SDLK_KP_HEXADECIMAL :: Keycode
 pattern SDLK_KP_HEXADECIMAL = (#const SDLK_KP_HEXADECIMAL) :: Keycode
+pattern SDLK_LCTRL :: Keycode
 pattern SDLK_LCTRL = (#const SDLK_LCTRL) :: Keycode
+pattern SDLK_LSHIFT :: Keycode
 pattern SDLK_LSHIFT = (#const SDLK_LSHIFT) :: Keycode
+pattern SDLK_LALT :: Keycode
 pattern SDLK_LALT = (#const SDLK_LALT) :: Keycode
+pattern SDLK_LGUI :: Keycode
 pattern SDLK_LGUI = (#const SDLK_LGUI) :: Keycode
+pattern SDLK_RCTRL :: Keycode
 pattern SDLK_RCTRL = (#const SDLK_RCTRL) :: Keycode
+pattern SDLK_RSHIFT :: Keycode
 pattern SDLK_RSHIFT = (#const SDLK_RSHIFT) :: Keycode
+pattern SDLK_RALT :: Keycode
 pattern SDLK_RALT = (#const SDLK_RALT) :: Keycode
+pattern SDLK_RGUI :: Keycode
 pattern SDLK_RGUI = (#const SDLK_RGUI) :: Keycode
+pattern SDLK_MODE :: Keycode
 pattern SDLK_MODE = (#const SDLK_MODE) :: Keycode
+pattern SDLK_AUDIONEXT :: Keycode
 pattern SDLK_AUDIONEXT = (#const SDLK_AUDIONEXT) :: Keycode
+pattern SDLK_AUDIOPREV :: Keycode
 pattern SDLK_AUDIOPREV = (#const SDLK_AUDIOPREV) :: Keycode
+pattern SDLK_AUDIOSTOP :: Keycode
 pattern SDLK_AUDIOSTOP = (#const SDLK_AUDIOSTOP) :: Keycode
+pattern SDLK_AUDIOPLAY :: Keycode
 pattern SDLK_AUDIOPLAY = (#const SDLK_AUDIOPLAY) :: Keycode
+pattern SDLK_AUDIOMUTE :: Keycode
 pattern SDLK_AUDIOMUTE = (#const SDLK_AUDIOMUTE) :: Keycode
+pattern SDLK_MEDIASELECT :: Keycode
 pattern SDLK_MEDIASELECT = (#const SDLK_MEDIASELECT) :: Keycode
+pattern SDLK_WWW :: Keycode
 pattern SDLK_WWW = (#const SDLK_WWW) :: Keycode
+pattern SDLK_MAIL :: Keycode
 pattern SDLK_MAIL = (#const SDLK_MAIL) :: Keycode
+pattern SDLK_CALCULATOR :: Keycode
 pattern SDLK_CALCULATOR = (#const SDLK_CALCULATOR) :: Keycode
+pattern SDLK_COMPUTER :: Keycode
 pattern SDLK_COMPUTER = (#const SDLK_COMPUTER) :: Keycode
+pattern SDLK_AC_SEARCH :: Keycode
 pattern SDLK_AC_SEARCH = (#const SDLK_AC_SEARCH) :: Keycode
+pattern SDLK_AC_HOME :: Keycode
 pattern SDLK_AC_HOME = (#const SDLK_AC_HOME) :: Keycode
+pattern SDLK_AC_BACK :: Keycode
 pattern SDLK_AC_BACK = (#const SDLK_AC_BACK) :: Keycode
+pattern SDLK_AC_FORWARD :: Keycode
 pattern SDLK_AC_FORWARD = (#const SDLK_AC_FORWARD) :: Keycode
+pattern SDLK_AC_STOP :: Keycode
 pattern SDLK_AC_STOP = (#const SDLK_AC_STOP) :: Keycode
+pattern SDLK_AC_REFRESH :: Keycode
 pattern SDLK_AC_REFRESH = (#const SDLK_AC_REFRESH) :: Keycode
+pattern SDLK_AC_BOOKMARKS :: Keycode
 pattern SDLK_AC_BOOKMARKS = (#const SDLK_AC_BOOKMARKS) :: Keycode
+pattern SDLK_BRIGHTNESSDOWN :: Keycode
 pattern SDLK_BRIGHTNESSDOWN = (#const SDLK_BRIGHTNESSDOWN) :: Keycode
+pattern SDLK_BRIGHTNESSUP :: Keycode
 pattern SDLK_BRIGHTNESSUP = (#const SDLK_BRIGHTNESSUP) :: Keycode
+pattern SDLK_DISPLAYSWITCH :: Keycode
 pattern SDLK_DISPLAYSWITCH = (#const SDLK_DISPLAYSWITCH) :: Keycode
+pattern SDLK_KBDILLUMTOGGLE :: Keycode
 pattern SDLK_KBDILLUMTOGGLE = (#const SDLK_KBDILLUMTOGGLE) :: Keycode
+pattern SDLK_KBDILLUMDOWN :: Keycode
 pattern SDLK_KBDILLUMDOWN = (#const SDLK_KBDILLUMDOWN) :: Keycode
+pattern SDLK_KBDILLUMUP :: Keycode
 pattern SDLK_KBDILLUMUP = (#const SDLK_KBDILLUMUP) :: Keycode
+pattern SDLK_EJECT :: Keycode
 pattern SDLK_EJECT = (#const SDLK_EJECT) :: Keycode
+pattern SDLK_SLEEP :: Keycode
 pattern SDLK_SLEEP = (#const SDLK_SLEEP) :: Keycode
 
+pattern KMOD_NONE :: forall a. (Num a, Eq a) => a
 pattern KMOD_NONE = (#const KMOD_NONE)
+pattern KMOD_LSHIFT :: forall a. (Num a, Eq a) => a
 pattern KMOD_LSHIFT = (#const KMOD_LSHIFT)
+pattern KMOD_RSHIFT :: forall a. (Num a, Eq a) => a
 pattern KMOD_RSHIFT = (#const KMOD_RSHIFT)
+pattern KMOD_SHIFT :: forall a. (Num a, Eq a) => a
 pattern KMOD_SHIFT = (#const KMOD_SHIFT)
+pattern KMOD_LCTRL :: forall a. (Num a, Eq a) => a
 pattern KMOD_LCTRL = (#const KMOD_LCTRL)
+pattern KMOD_RCTRL :: forall a. (Num a, Eq a) => a
 pattern KMOD_RCTRL = (#const KMOD_RCTRL)
+pattern KMOD_CTRL :: forall a. (Num a, Eq a) => a
 pattern KMOD_CTRL = (#const KMOD_CTRL)
+pattern KMOD_LALT :: forall a. (Num a, Eq a) => a
 pattern KMOD_LALT = (#const KMOD_LALT)
+pattern KMOD_RALT :: forall a. (Num a, Eq a) => a
 pattern KMOD_RALT = (#const KMOD_RALT)
+pattern KMOD_ALT :: forall a. (Num a, Eq a) => a
 pattern KMOD_ALT = (#const KMOD_ALT)
+pattern KMOD_LGUI :: forall a. (Num a, Eq a) => a
 pattern KMOD_LGUI = (#const KMOD_LGUI)
+pattern KMOD_RGUI :: forall a. (Num a, Eq a) => a
 pattern KMOD_RGUI = (#const KMOD_RGUI)
+pattern KMOD_GUI :: forall a. (Num a, Eq a) => a
 pattern KMOD_GUI = (#const KMOD_GUI)
+pattern KMOD_NUM :: forall a. (Num a, Eq a) => a
 pattern KMOD_NUM = (#const KMOD_NUM)
+pattern KMOD_CAPS :: forall a. (Num a, Eq a) => a
 pattern KMOD_CAPS = (#const KMOD_CAPS)
+pattern KMOD_MODE :: forall a. (Num a, Eq a) => a
 pattern KMOD_MODE = (#const KMOD_MODE)
+pattern KMOD_RESERVED :: forall a. (Num a, Eq a) => a
 pattern KMOD_RESERVED = (#const KMOD_RESERVED)
 
-pattern SDL_LOG_PRIORITY_VERBOSE = (#const SDL_LOG_PRIORITY_VERBOSE) :: LogPriority
-pattern SDL_LOG_PRIORITY_DEBUG = (#const SDL_LOG_PRIORITY_DEBUG) :: LogPriority
-pattern SDL_LOG_PRIORITY_INFO = (#const SDL_LOG_PRIORITY_INFO) :: LogPriority
-pattern SDL_LOG_PRIORITY_WARN = (#const SDL_LOG_PRIORITY_WARN) :: LogPriority
-pattern SDL_LOG_PRIORITY_ERROR = (#const SDL_LOG_PRIORITY_ERROR) :: LogPriority
-pattern SDL_LOG_PRIORITY_CRITICAL = (#const SDL_LOG_PRIORITY_CRITICAL) :: LogPriority
-pattern SDL_NUM_LOG_PRIORITIES = (#const SDL_NUM_LOG_PRIORITIES) :: LogPriority
+pattern SDL_LOG_PRIORITY_VERBOSE :: LogPriority
+pattern SDL_LOG_PRIORITY_VERBOSE = (#const SDL_LOG_PRIORITY_VERBOSE)
+pattern SDL_LOG_PRIORITY_DEBUG :: LogPriority
+pattern SDL_LOG_PRIORITY_DEBUG = (#const SDL_LOG_PRIORITY_DEBUG)
+pattern SDL_LOG_PRIORITY_INFO :: LogPriority
+pattern SDL_LOG_PRIORITY_INFO = (#const SDL_LOG_PRIORITY_INFO)
+pattern SDL_LOG_PRIORITY_WARN :: LogPriority
+pattern SDL_LOG_PRIORITY_WARN = (#const SDL_LOG_PRIORITY_WARN)
+pattern SDL_LOG_PRIORITY_ERROR :: LogPriority
+pattern SDL_LOG_PRIORITY_ERROR = (#const SDL_LOG_PRIORITY_ERROR)
+pattern SDL_LOG_PRIORITY_CRITICAL :: LogPriority
+pattern SDL_LOG_PRIORITY_CRITICAL = (#const SDL_LOG_PRIORITY_CRITICAL)
+pattern SDL_NUM_LOG_PRIORITIES :: LogPriority
+pattern SDL_NUM_LOG_PRIORITIES = (#const SDL_NUM_LOG_PRIORITIES)
 
-pattern SDL_POWERSTATE_UNKNOWN = (#const SDL_POWERSTATE_UNKNOWN) :: PowerState
-pattern SDL_POWERSTATE_ON_BATTERY = (#const SDL_POWERSTATE_ON_BATTERY) :: PowerState
-pattern SDL_POWERSTATE_NO_BATTERY = (#const SDL_POWERSTATE_NO_BATTERY) :: PowerState
-pattern SDL_POWERSTATE_CHARGING = (#const SDL_POWERSTATE_CHARGING) :: PowerState
-pattern SDL_POWERSTATE_CHARGED = (#const SDL_POWERSTATE_CHARGED) :: PowerState
+pattern SDL_POWERSTATE_UNKNOWN :: PowerState
+pattern SDL_POWERSTATE_UNKNOWN = (#const SDL_POWERSTATE_UNKNOWN)
+pattern SDL_POWERSTATE_ON_BATTERY :: PowerState
+pattern SDL_POWERSTATE_ON_BATTERY = (#const SDL_POWERSTATE_ON_BATTERY)
+pattern SDL_POWERSTATE_NO_BATTERY :: PowerState
+pattern SDL_POWERSTATE_NO_BATTERY = (#const SDL_POWERSTATE_NO_BATTERY)
+pattern SDL_POWERSTATE_CHARGING :: PowerState
+pattern SDL_POWERSTATE_CHARGING = (#const SDL_POWERSTATE_CHARGING)
+pattern SDL_POWERSTATE_CHARGED :: PowerState
+pattern SDL_POWERSTATE_CHARGED = (#const SDL_POWERSTATE_CHARGED)
 
-pattern SDL_FLIP_NONE = (#const SDL_FLIP_NONE) :: RendererFlip
-pattern SDL_FLIP_HORIZONTAL = (#const SDL_FLIP_HORIZONTAL) :: RendererFlip
-pattern SDL_FLIP_VERTICAL = (#const SDL_FLIP_VERTICAL) :: RendererFlip
+pattern SDL_FLIP_NONE :: RendererFlip
+pattern SDL_FLIP_NONE = (#const SDL_FLIP_NONE)
+pattern SDL_FLIP_HORIZONTAL :: RendererFlip
+pattern SDL_FLIP_HORIZONTAL = (#const SDL_FLIP_HORIZONTAL)
+pattern SDL_FLIP_VERTICAL :: RendererFlip
+pattern SDL_FLIP_VERTICAL = (#const SDL_FLIP_VERTICAL)
 
-pattern SDL_SCANCODE_UNKNOWN = (#const SDL_SCANCODE_UNKNOWN) :: Scancode
-pattern SDL_SCANCODE_A = (#const SDL_SCANCODE_A) :: Scancode
-pattern SDL_SCANCODE_B = (#const SDL_SCANCODE_B) :: Scancode
-pattern SDL_SCANCODE_C = (#const SDL_SCANCODE_C) :: Scancode
-pattern SDL_SCANCODE_D = (#const SDL_SCANCODE_D) :: Scancode
-pattern SDL_SCANCODE_E = (#const SDL_SCANCODE_E) :: Scancode
-pattern SDL_SCANCODE_F = (#const SDL_SCANCODE_F) :: Scancode
-pattern SDL_SCANCODE_G = (#const SDL_SCANCODE_G) :: Scancode
-pattern SDL_SCANCODE_H = (#const SDL_SCANCODE_H) :: Scancode
-pattern SDL_SCANCODE_I = (#const SDL_SCANCODE_I) :: Scancode
-pattern SDL_SCANCODE_J = (#const SDL_SCANCODE_J) :: Scancode
-pattern SDL_SCANCODE_K = (#const SDL_SCANCODE_K) :: Scancode
-pattern SDL_SCANCODE_L = (#const SDL_SCANCODE_L) :: Scancode
-pattern SDL_SCANCODE_M = (#const SDL_SCANCODE_M) :: Scancode
-pattern SDL_SCANCODE_N = (#const SDL_SCANCODE_N) :: Scancode
-pattern SDL_SCANCODE_O = (#const SDL_SCANCODE_O) :: Scancode
-pattern SDL_SCANCODE_P = (#const SDL_SCANCODE_P) :: Scancode
-pattern SDL_SCANCODE_Q = (#const SDL_SCANCODE_Q) :: Scancode
-pattern SDL_SCANCODE_R = (#const SDL_SCANCODE_R) :: Scancode
-pattern SDL_SCANCODE_S = (#const SDL_SCANCODE_S) :: Scancode
-pattern SDL_SCANCODE_T = (#const SDL_SCANCODE_T) :: Scancode
-pattern SDL_SCANCODE_U = (#const SDL_SCANCODE_U) :: Scancode
-pattern SDL_SCANCODE_V = (#const SDL_SCANCODE_V) :: Scancode
-pattern SDL_SCANCODE_W = (#const SDL_SCANCODE_W) :: Scancode
-pattern SDL_SCANCODE_X = (#const SDL_SCANCODE_X) :: Scancode
-pattern SDL_SCANCODE_Y = (#const SDL_SCANCODE_Y) :: Scancode
-pattern SDL_SCANCODE_Z = (#const SDL_SCANCODE_Z) :: Scancode
-pattern SDL_SCANCODE_1 = (#const SDL_SCANCODE_1) :: Scancode
-pattern SDL_SCANCODE_2 = (#const SDL_SCANCODE_2) :: Scancode
-pattern SDL_SCANCODE_3 = (#const SDL_SCANCODE_3) :: Scancode
-pattern SDL_SCANCODE_4 = (#const SDL_SCANCODE_4) :: Scancode
-pattern SDL_SCANCODE_5 = (#const SDL_SCANCODE_5) :: Scancode
-pattern SDL_SCANCODE_6 = (#const SDL_SCANCODE_6) :: Scancode
-pattern SDL_SCANCODE_7 = (#const SDL_SCANCODE_7) :: Scancode
-pattern SDL_SCANCODE_8 = (#const SDL_SCANCODE_8) :: Scancode
-pattern SDL_SCANCODE_9 = (#const SDL_SCANCODE_9) :: Scancode
-pattern SDL_SCANCODE_0 = (#const SDL_SCANCODE_0) :: Scancode
-pattern SDL_SCANCODE_RETURN = (#const SDL_SCANCODE_RETURN) :: Scancode
-pattern SDL_SCANCODE_ESCAPE = (#const SDL_SCANCODE_ESCAPE) :: Scancode
-pattern SDL_SCANCODE_BACKSPACE = (#const SDL_SCANCODE_BACKSPACE) :: Scancode
-pattern SDL_SCANCODE_TAB = (#const SDL_SCANCODE_TAB) :: Scancode
-pattern SDL_SCANCODE_SPACE = (#const SDL_SCANCODE_SPACE) :: Scancode
-pattern SDL_SCANCODE_MINUS = (#const SDL_SCANCODE_MINUS) :: Scancode
-pattern SDL_SCANCODE_EQUALS = (#const SDL_SCANCODE_EQUALS) :: Scancode
-pattern SDL_SCANCODE_LEFTBRACKET = (#const SDL_SCANCODE_LEFTBRACKET) :: Scancode
-pattern SDL_SCANCODE_RIGHTBRACKET = (#const SDL_SCANCODE_RIGHTBRACKET) :: Scancode
-pattern SDL_SCANCODE_BACKSLASH = (#const SDL_SCANCODE_BACKSLASH) :: Scancode
-pattern SDL_SCANCODE_NONUSHASH = (#const SDL_SCANCODE_NONUSHASH) :: Scancode
-pattern SDL_SCANCODE_SEMICOLON = (#const SDL_SCANCODE_SEMICOLON) :: Scancode
-pattern SDL_SCANCODE_APOSTROPHE = (#const SDL_SCANCODE_APOSTROPHE) :: Scancode
-pattern SDL_SCANCODE_GRAVE = (#const SDL_SCANCODE_GRAVE) :: Scancode
-pattern SDL_SCANCODE_COMMA = (#const SDL_SCANCODE_COMMA) :: Scancode
-pattern SDL_SCANCODE_PERIOD = (#const SDL_SCANCODE_PERIOD) :: Scancode
-pattern SDL_SCANCODE_SLASH = (#const SDL_SCANCODE_SLASH) :: Scancode
-pattern SDL_SCANCODE_CAPSLOCK = (#const SDL_SCANCODE_CAPSLOCK) :: Scancode
-pattern SDL_SCANCODE_F1 = (#const SDL_SCANCODE_F1) :: Scancode
-pattern SDL_SCANCODE_F2 = (#const SDL_SCANCODE_F2) :: Scancode
-pattern SDL_SCANCODE_F3 = (#const SDL_SCANCODE_F3) :: Scancode
-pattern SDL_SCANCODE_F4 = (#const SDL_SCANCODE_F4) :: Scancode
-pattern SDL_SCANCODE_F5 = (#const SDL_SCANCODE_F5) :: Scancode
-pattern SDL_SCANCODE_F6 = (#const SDL_SCANCODE_F6) :: Scancode
-pattern SDL_SCANCODE_F7 = (#const SDL_SCANCODE_F7) :: Scancode
-pattern SDL_SCANCODE_F8 = (#const SDL_SCANCODE_F8) :: Scancode
-pattern SDL_SCANCODE_F9 = (#const SDL_SCANCODE_F9) :: Scancode
-pattern SDL_SCANCODE_F10 = (#const SDL_SCANCODE_F10) :: Scancode
-pattern SDL_SCANCODE_F11 = (#const SDL_SCANCODE_F11) :: Scancode
-pattern SDL_SCANCODE_F12 = (#const SDL_SCANCODE_F12) :: Scancode
-pattern SDL_SCANCODE_PRINTSCREEN = (#const SDL_SCANCODE_PRINTSCREEN) :: Scancode
-pattern SDL_SCANCODE_SCROLLLOCK = (#const SDL_SCANCODE_SCROLLLOCK) :: Scancode
-pattern SDL_SCANCODE_PAUSE = (#const SDL_SCANCODE_PAUSE) :: Scancode
-pattern SDL_SCANCODE_INSERT = (#const SDL_SCANCODE_INSERT) :: Scancode
-pattern SDL_SCANCODE_HOME = (#const SDL_SCANCODE_HOME) :: Scancode
-pattern SDL_SCANCODE_PAGEUP = (#const SDL_SCANCODE_PAGEUP) :: Scancode
-pattern SDL_SCANCODE_DELETE = (#const SDL_SCANCODE_DELETE) :: Scancode
-pattern SDL_SCANCODE_END = (#const SDL_SCANCODE_END) :: Scancode
-pattern SDL_SCANCODE_PAGEDOWN = (#const SDL_SCANCODE_PAGEDOWN) :: Scancode
-pattern SDL_SCANCODE_RIGHT = (#const SDL_SCANCODE_RIGHT) :: Scancode
-pattern SDL_SCANCODE_LEFT = (#const SDL_SCANCODE_LEFT) :: Scancode
-pattern SDL_SCANCODE_DOWN = (#const SDL_SCANCODE_DOWN) :: Scancode
-pattern SDL_SCANCODE_UP = (#const SDL_SCANCODE_UP) :: Scancode
-pattern SDL_SCANCODE_NUMLOCKCLEAR = (#const SDL_SCANCODE_NUMLOCKCLEAR) :: Scancode
-pattern SDL_SCANCODE_KP_DIVIDE = (#const SDL_SCANCODE_KP_DIVIDE) :: Scancode
-pattern SDL_SCANCODE_KP_MULTIPLY = (#const SDL_SCANCODE_KP_MULTIPLY) :: Scancode
-pattern SDL_SCANCODE_KP_MINUS = (#const SDL_SCANCODE_KP_MINUS) :: Scancode
-pattern SDL_SCANCODE_KP_PLUS = (#const SDL_SCANCODE_KP_PLUS) :: Scancode
-pattern SDL_SCANCODE_KP_ENTER = (#const SDL_SCANCODE_KP_ENTER) :: Scancode
-pattern SDL_SCANCODE_KP_1 = (#const SDL_SCANCODE_KP_1) :: Scancode
-pattern SDL_SCANCODE_KP_2 = (#const SDL_SCANCODE_KP_2) :: Scancode
-pattern SDL_SCANCODE_KP_3 = (#const SDL_SCANCODE_KP_3) :: Scancode
-pattern SDL_SCANCODE_KP_4 = (#const SDL_SCANCODE_KP_4) :: Scancode
-pattern SDL_SCANCODE_KP_5 = (#const SDL_SCANCODE_KP_5) :: Scancode
-pattern SDL_SCANCODE_KP_6 = (#const SDL_SCANCODE_KP_6) :: Scancode
-pattern SDL_SCANCODE_KP_7 = (#const SDL_SCANCODE_KP_7) :: Scancode
-pattern SDL_SCANCODE_KP_8 = (#const SDL_SCANCODE_KP_8) :: Scancode
-pattern SDL_SCANCODE_KP_9 = (#const SDL_SCANCODE_KP_9) :: Scancode
-pattern SDL_SCANCODE_KP_0 = (#const SDL_SCANCODE_KP_0) :: Scancode
-pattern SDL_SCANCODE_KP_PERIOD = (#const SDL_SCANCODE_KP_PERIOD) :: Scancode
-pattern SDL_SCANCODE_NONUSBACKSLASH = (#const SDL_SCANCODE_NONUSBACKSLASH) :: Scancode
-pattern SDL_SCANCODE_APPLICATION = (#const SDL_SCANCODE_APPLICATION) :: Scancode
-pattern SDL_SCANCODE_POWER = (#const SDL_SCANCODE_POWER) :: Scancode
-pattern SDL_SCANCODE_KP_EQUALS = (#const SDL_SCANCODE_KP_EQUALS) :: Scancode
-pattern SDL_SCANCODE_F13 = (#const SDL_SCANCODE_F13) :: Scancode
-pattern SDL_SCANCODE_F14 = (#const SDL_SCANCODE_F14) :: Scancode
-pattern SDL_SCANCODE_F15 = (#const SDL_SCANCODE_F15) :: Scancode
-pattern SDL_SCANCODE_F16 = (#const SDL_SCANCODE_F16) :: Scancode
-pattern SDL_SCANCODE_F17 = (#const SDL_SCANCODE_F17) :: Scancode
-pattern SDL_SCANCODE_F18 = (#const SDL_SCANCODE_F18) :: Scancode
-pattern SDL_SCANCODE_F19 = (#const SDL_SCANCODE_F19) :: Scancode
-pattern SDL_SCANCODE_F20 = (#const SDL_SCANCODE_F20) :: Scancode
-pattern SDL_SCANCODE_F21 = (#const SDL_SCANCODE_F21) :: Scancode
-pattern SDL_SCANCODE_F22 = (#const SDL_SCANCODE_F22) :: Scancode
-pattern SDL_SCANCODE_F23 = (#const SDL_SCANCODE_F23) :: Scancode
-pattern SDL_SCANCODE_F24 = (#const SDL_SCANCODE_F24) :: Scancode
-pattern SDL_SCANCODE_EXECUTE = (#const SDL_SCANCODE_EXECUTE) :: Scancode
-pattern SDL_SCANCODE_HELP = (#const SDL_SCANCODE_HELP) :: Scancode
-pattern SDL_SCANCODE_MENU = (#const SDL_SCANCODE_MENU) :: Scancode
-pattern SDL_SCANCODE_SELECT = (#const SDL_SCANCODE_SELECT) :: Scancode
-pattern SDL_SCANCODE_STOP = (#const SDL_SCANCODE_STOP) :: Scancode
-pattern SDL_SCANCODE_AGAIN = (#const SDL_SCANCODE_AGAIN) :: Scancode
-pattern SDL_SCANCODE_UNDO = (#const SDL_SCANCODE_UNDO) :: Scancode
-pattern SDL_SCANCODE_CUT = (#const SDL_SCANCODE_CUT) :: Scancode
-pattern SDL_SCANCODE_COPY = (#const SDL_SCANCODE_COPY) :: Scancode
-pattern SDL_SCANCODE_PASTE = (#const SDL_SCANCODE_PASTE) :: Scancode
-pattern SDL_SCANCODE_FIND = (#const SDL_SCANCODE_FIND) :: Scancode
-pattern SDL_SCANCODE_MUTE = (#const SDL_SCANCODE_MUTE) :: Scancode
-pattern SDL_SCANCODE_VOLUMEUP = (#const SDL_SCANCODE_VOLUMEUP) :: Scancode
-pattern SDL_SCANCODE_VOLUMEDOWN = (#const SDL_SCANCODE_VOLUMEDOWN) :: Scancode
-pattern SDL_SCANCODE_KP_COMMA = (#const SDL_SCANCODE_KP_COMMA) :: Scancode
-pattern SDL_SCANCODE_KP_EQUALSAS400 = (#const SDL_SCANCODE_KP_EQUALSAS400) :: Scancode
-pattern SDL_SCANCODE_INTERNATIONAL1 = (#const SDL_SCANCODE_INTERNATIONAL1) :: Scancode
-pattern SDL_SCANCODE_INTERNATIONAL2 = (#const SDL_SCANCODE_INTERNATIONAL2) :: Scancode
-pattern SDL_SCANCODE_INTERNATIONAL3 = (#const SDL_SCANCODE_INTERNATIONAL3) :: Scancode
-pattern SDL_SCANCODE_INTERNATIONAL4 = (#const SDL_SCANCODE_INTERNATIONAL4) :: Scancode
-pattern SDL_SCANCODE_INTERNATIONAL5 = (#const SDL_SCANCODE_INTERNATIONAL5) :: Scancode
-pattern SDL_SCANCODE_INTERNATIONAL6 = (#const SDL_SCANCODE_INTERNATIONAL6) :: Scancode
-pattern SDL_SCANCODE_INTERNATIONAL7 = (#const SDL_SCANCODE_INTERNATIONAL7) :: Scancode
-pattern SDL_SCANCODE_INTERNATIONAL8 = (#const SDL_SCANCODE_INTERNATIONAL8) :: Scancode
-pattern SDL_SCANCODE_INTERNATIONAL9 = (#const SDL_SCANCODE_INTERNATIONAL9) :: Scancode
-pattern SDL_SCANCODE_LANG1 = (#const SDL_SCANCODE_LANG1) :: Scancode
-pattern SDL_SCANCODE_LANG2 = (#const SDL_SCANCODE_LANG2) :: Scancode
-pattern SDL_SCANCODE_LANG3 = (#const SDL_SCANCODE_LANG3) :: Scancode
-pattern SDL_SCANCODE_LANG4 = (#const SDL_SCANCODE_LANG4) :: Scancode
-pattern SDL_SCANCODE_LANG5 = (#const SDL_SCANCODE_LANG5) :: Scancode
-pattern SDL_SCANCODE_LANG6 = (#const SDL_SCANCODE_LANG6) :: Scancode
-pattern SDL_SCANCODE_LANG7 = (#const SDL_SCANCODE_LANG7) :: Scancode
-pattern SDL_SCANCODE_LANG8 = (#const SDL_SCANCODE_LANG8) :: Scancode
-pattern SDL_SCANCODE_LANG9 = (#const SDL_SCANCODE_LANG9) :: Scancode
-pattern SDL_SCANCODE_ALTERASE = (#const SDL_SCANCODE_ALTERASE) :: Scancode
-pattern SDL_SCANCODE_SYSREQ = (#const SDL_SCANCODE_SYSREQ) :: Scancode
-pattern SDL_SCANCODE_CANCEL = (#const SDL_SCANCODE_CANCEL) :: Scancode
-pattern SDL_SCANCODE_CLEAR = (#const SDL_SCANCODE_CLEAR) :: Scancode
-pattern SDL_SCANCODE_PRIOR = (#const SDL_SCANCODE_PRIOR) :: Scancode
-pattern SDL_SCANCODE_RETURN2 = (#const SDL_SCANCODE_RETURN2) :: Scancode
-pattern SDL_SCANCODE_SEPARATOR = (#const SDL_SCANCODE_SEPARATOR) :: Scancode
-pattern SDL_SCANCODE_OUT = (#const SDL_SCANCODE_OUT) :: Scancode
-pattern SDL_SCANCODE_OPER = (#const SDL_SCANCODE_OPER) :: Scancode
-pattern SDL_SCANCODE_CLEARAGAIN = (#const SDL_SCANCODE_CLEARAGAIN) :: Scancode
-pattern SDL_SCANCODE_CRSEL = (#const SDL_SCANCODE_CRSEL) :: Scancode
-pattern SDL_SCANCODE_EXSEL = (#const SDL_SCANCODE_EXSEL) :: Scancode
-pattern SDL_SCANCODE_KP_00 = (#const SDL_SCANCODE_KP_00) :: Scancode
-pattern SDL_SCANCODE_KP_000 = (#const SDL_SCANCODE_KP_000) :: Scancode
-pattern SDL_SCANCODE_THOUSANDSSEPARATOR = (#const SDL_SCANCODE_THOUSANDSSEPARATOR) :: Scancode
-pattern SDL_SCANCODE_DECIMALSEPARATOR = (#const SDL_SCANCODE_DECIMALSEPARATOR) :: Scancode
-pattern SDL_SCANCODE_CURRENCYUNIT = (#const SDL_SCANCODE_CURRENCYUNIT) :: Scancode
-pattern SDL_SCANCODE_CURRENCYSUBUNIT = (#const SDL_SCANCODE_CURRENCYSUBUNIT) :: Scancode
-pattern SDL_SCANCODE_KP_LEFTPAREN = (#const SDL_SCANCODE_KP_LEFTPAREN) :: Scancode
-pattern SDL_SCANCODE_KP_RIGHTPAREN = (#const SDL_SCANCODE_KP_RIGHTPAREN) :: Scancode
-pattern SDL_SCANCODE_KP_LEFTBRACE = (#const SDL_SCANCODE_KP_LEFTBRACE) :: Scancode
-pattern SDL_SCANCODE_KP_RIGHTBRACE = (#const SDL_SCANCODE_KP_RIGHTBRACE) :: Scancode
-pattern SDL_SCANCODE_KP_TAB = (#const SDL_SCANCODE_KP_TAB) :: Scancode
-pattern SDL_SCANCODE_KP_BACKSPACE = (#const SDL_SCANCODE_KP_BACKSPACE) :: Scancode
-pattern SDL_SCANCODE_KP_A = (#const SDL_SCANCODE_KP_A) :: Scancode
-pattern SDL_SCANCODE_KP_B = (#const SDL_SCANCODE_KP_B) :: Scancode
-pattern SDL_SCANCODE_KP_C = (#const SDL_SCANCODE_KP_C) :: Scancode
-pattern SDL_SCANCODE_KP_D = (#const SDL_SCANCODE_KP_D) :: Scancode
-pattern SDL_SCANCODE_KP_E = (#const SDL_SCANCODE_KP_E) :: Scancode
-pattern SDL_SCANCODE_KP_F = (#const SDL_SCANCODE_KP_F) :: Scancode
-pattern SDL_SCANCODE_KP_XOR = (#const SDL_SCANCODE_KP_XOR) :: Scancode
-pattern SDL_SCANCODE_KP_POWER = (#const SDL_SCANCODE_KP_POWER) :: Scancode
-pattern SDL_SCANCODE_KP_PERCENT = (#const SDL_SCANCODE_KP_PERCENT) :: Scancode
-pattern SDL_SCANCODE_KP_LESS = (#const SDL_SCANCODE_KP_LESS) :: Scancode
-pattern SDL_SCANCODE_KP_GREATER = (#const SDL_SCANCODE_KP_GREATER) :: Scancode
-pattern SDL_SCANCODE_KP_AMPERSAND = (#const SDL_SCANCODE_KP_AMPERSAND) :: Scancode
-pattern SDL_SCANCODE_KP_DBLAMPERSAND = (#const SDL_SCANCODE_KP_DBLAMPERSAND) :: Scancode
-pattern SDL_SCANCODE_KP_VERTICALBAR = (#const SDL_SCANCODE_KP_VERTICALBAR) :: Scancode
-pattern SDL_SCANCODE_KP_DBLVERTICALBAR = (#const SDL_SCANCODE_KP_DBLVERTICALBAR) :: Scancode
-pattern SDL_SCANCODE_KP_COLON = (#const SDL_SCANCODE_KP_COLON) :: Scancode
-pattern SDL_SCANCODE_KP_HASH = (#const SDL_SCANCODE_KP_HASH) :: Scancode
-pattern SDL_SCANCODE_KP_SPACE = (#const SDL_SCANCODE_KP_SPACE) :: Scancode
-pattern SDL_SCANCODE_KP_AT = (#const SDL_SCANCODE_KP_AT) :: Scancode
-pattern SDL_SCANCODE_KP_EXCLAM = (#const SDL_SCANCODE_KP_EXCLAM) :: Scancode
-pattern SDL_SCANCODE_KP_MEMSTORE = (#const SDL_SCANCODE_KP_MEMSTORE) :: Scancode
-pattern SDL_SCANCODE_KP_MEMRECALL = (#const SDL_SCANCODE_KP_MEMRECALL) :: Scancode
-pattern SDL_SCANCODE_KP_MEMCLEAR = (#const SDL_SCANCODE_KP_MEMCLEAR) :: Scancode
-pattern SDL_SCANCODE_KP_MEMADD = (#const SDL_SCANCODE_KP_MEMADD) :: Scancode
-pattern SDL_SCANCODE_KP_MEMSUBTRACT = (#const SDL_SCANCODE_KP_MEMSUBTRACT) :: Scancode
-pattern SDL_SCANCODE_KP_MEMMULTIPLY = (#const SDL_SCANCODE_KP_MEMMULTIPLY) :: Scancode
-pattern SDL_SCANCODE_KP_MEMDIVIDE = (#const SDL_SCANCODE_KP_MEMDIVIDE) :: Scancode
-pattern SDL_SCANCODE_KP_PLUSMINUS = (#const SDL_SCANCODE_KP_PLUSMINUS) :: Scancode
-pattern SDL_SCANCODE_KP_CLEAR = (#const SDL_SCANCODE_KP_CLEAR) :: Scancode
-pattern SDL_SCANCODE_KP_CLEARENTRY = (#const SDL_SCANCODE_KP_CLEARENTRY) :: Scancode
-pattern SDL_SCANCODE_KP_BINARY = (#const SDL_SCANCODE_KP_BINARY) :: Scancode
-pattern SDL_SCANCODE_KP_OCTAL = (#const SDL_SCANCODE_KP_OCTAL) :: Scancode
-pattern SDL_SCANCODE_KP_DECIMAL = (#const SDL_SCANCODE_KP_DECIMAL) :: Scancode
-pattern SDL_SCANCODE_KP_HEXADECIMAL = (#const SDL_SCANCODE_KP_HEXADECIMAL) :: Scancode
-pattern SDL_SCANCODE_LCTRL = (#const SDL_SCANCODE_LCTRL) :: Scancode
-pattern SDL_SCANCODE_LSHIFT = (#const SDL_SCANCODE_LSHIFT) :: Scancode
-pattern SDL_SCANCODE_LALT = (#const SDL_SCANCODE_LALT) :: Scancode
-pattern SDL_SCANCODE_LGUI = (#const SDL_SCANCODE_LGUI) :: Scancode
-pattern SDL_SCANCODE_RCTRL = (#const SDL_SCANCODE_RCTRL) :: Scancode
-pattern SDL_SCANCODE_RSHIFT = (#const SDL_SCANCODE_RSHIFT) :: Scancode
-pattern SDL_SCANCODE_RALT = (#const SDL_SCANCODE_RALT) :: Scancode
-pattern SDL_SCANCODE_RGUI = (#const SDL_SCANCODE_RGUI) :: Scancode
-pattern SDL_SCANCODE_MODE = (#const SDL_SCANCODE_MODE) :: Scancode
-pattern SDL_SCANCODE_AUDIONEXT = (#const SDL_SCANCODE_AUDIONEXT) :: Scancode
-pattern SDL_SCANCODE_AUDIOPREV = (#const SDL_SCANCODE_AUDIOPREV) :: Scancode
-pattern SDL_SCANCODE_AUDIOSTOP = (#const SDL_SCANCODE_AUDIOSTOP) :: Scancode
-pattern SDL_SCANCODE_AUDIOPLAY = (#const SDL_SCANCODE_AUDIOPLAY) :: Scancode
-pattern SDL_SCANCODE_AUDIOMUTE = (#const SDL_SCANCODE_AUDIOMUTE) :: Scancode
-pattern SDL_SCANCODE_MEDIASELECT = (#const SDL_SCANCODE_MEDIASELECT) :: Scancode
-pattern SDL_SCANCODE_WWW = (#const SDL_SCANCODE_WWW) :: Scancode
-pattern SDL_SCANCODE_MAIL = (#const SDL_SCANCODE_MAIL) :: Scancode
-pattern SDL_SCANCODE_CALCULATOR = (#const SDL_SCANCODE_CALCULATOR) :: Scancode
-pattern SDL_SCANCODE_COMPUTER = (#const SDL_SCANCODE_COMPUTER) :: Scancode
-pattern SDL_SCANCODE_AC_SEARCH = (#const SDL_SCANCODE_AC_SEARCH) :: Scancode
-pattern SDL_SCANCODE_AC_HOME = (#const SDL_SCANCODE_AC_HOME) :: Scancode
-pattern SDL_SCANCODE_AC_BACK = (#const SDL_SCANCODE_AC_BACK) :: Scancode
-pattern SDL_SCANCODE_AC_FORWARD = (#const SDL_SCANCODE_AC_FORWARD) :: Scancode
-pattern SDL_SCANCODE_AC_STOP = (#const SDL_SCANCODE_AC_STOP) :: Scancode
-pattern SDL_SCANCODE_AC_REFRESH = (#const SDL_SCANCODE_AC_REFRESH) :: Scancode
-pattern SDL_SCANCODE_AC_BOOKMARKS = (#const SDL_SCANCODE_AC_BOOKMARKS) :: Scancode
-pattern SDL_SCANCODE_BRIGHTNESSDOWN = (#const SDL_SCANCODE_BRIGHTNESSDOWN) :: Scancode
-pattern SDL_SCANCODE_BRIGHTNESSUP = (#const SDL_SCANCODE_BRIGHTNESSUP) :: Scancode
-pattern SDL_SCANCODE_DISPLAYSWITCH = (#const SDL_SCANCODE_DISPLAYSWITCH) :: Scancode
-pattern SDL_SCANCODE_KBDILLUMTOGGLE = (#const SDL_SCANCODE_KBDILLUMTOGGLE) :: Scancode
-pattern SDL_SCANCODE_KBDILLUMDOWN = (#const SDL_SCANCODE_KBDILLUMDOWN) :: Scancode
-pattern SDL_SCANCODE_KBDILLUMUP = (#const SDL_SCANCODE_KBDILLUMUP) :: Scancode
-pattern SDL_SCANCODE_EJECT = (#const SDL_SCANCODE_EJECT) :: Scancode
-pattern SDL_SCANCODE_SLEEP = (#const SDL_SCANCODE_SLEEP) :: Scancode
-pattern SDL_SCANCODE_APP1 = (#const SDL_SCANCODE_APP1) :: Scancode
-pattern SDL_SCANCODE_APP2 = (#const SDL_SCANCODE_APP2) :: Scancode
-pattern SDL_NUM_SCANCODES = (#const SDL_NUM_SCANCODES) :: Scancode
+pattern SDL_SCANCODE_UNKNOWN :: Scancode
+pattern SDL_SCANCODE_UNKNOWN = (#const SDL_SCANCODE_UNKNOWN)
+pattern SDL_SCANCODE_A :: Scancode
+pattern SDL_SCANCODE_A = (#const SDL_SCANCODE_A)
+pattern SDL_SCANCODE_B :: Scancode
+pattern SDL_SCANCODE_B = (#const SDL_SCANCODE_B)
+pattern SDL_SCANCODE_C :: Scancode
+pattern SDL_SCANCODE_C = (#const SDL_SCANCODE_C)
+pattern SDL_SCANCODE_D :: Scancode
+pattern SDL_SCANCODE_D = (#const SDL_SCANCODE_D)
+pattern SDL_SCANCODE_E :: Scancode
+pattern SDL_SCANCODE_E = (#const SDL_SCANCODE_E)
+pattern SDL_SCANCODE_F :: Scancode
+pattern SDL_SCANCODE_F = (#const SDL_SCANCODE_F)
+pattern SDL_SCANCODE_G :: Scancode
+pattern SDL_SCANCODE_G = (#const SDL_SCANCODE_G)
+pattern SDL_SCANCODE_H :: Scancode
+pattern SDL_SCANCODE_H = (#const SDL_SCANCODE_H)
+pattern SDL_SCANCODE_I :: Scancode
+pattern SDL_SCANCODE_I = (#const SDL_SCANCODE_I)
+pattern SDL_SCANCODE_J :: Scancode
+pattern SDL_SCANCODE_J = (#const SDL_SCANCODE_J)
+pattern SDL_SCANCODE_K :: Scancode
+pattern SDL_SCANCODE_K = (#const SDL_SCANCODE_K)
+pattern SDL_SCANCODE_L :: Scancode
+pattern SDL_SCANCODE_L = (#const SDL_SCANCODE_L)
+pattern SDL_SCANCODE_M :: Scancode
+pattern SDL_SCANCODE_M = (#const SDL_SCANCODE_M)
+pattern SDL_SCANCODE_N :: Scancode
+pattern SDL_SCANCODE_N = (#const SDL_SCANCODE_N)
+pattern SDL_SCANCODE_O :: Scancode
+pattern SDL_SCANCODE_O = (#const SDL_SCANCODE_O)
+pattern SDL_SCANCODE_P :: Scancode
+pattern SDL_SCANCODE_P = (#const SDL_SCANCODE_P)
+pattern SDL_SCANCODE_Q :: Scancode
+pattern SDL_SCANCODE_Q = (#const SDL_SCANCODE_Q)
+pattern SDL_SCANCODE_R :: Scancode
+pattern SDL_SCANCODE_R = (#const SDL_SCANCODE_R)
+pattern SDL_SCANCODE_S :: Scancode
+pattern SDL_SCANCODE_S = (#const SDL_SCANCODE_S)
+pattern SDL_SCANCODE_T :: Scancode
+pattern SDL_SCANCODE_T = (#const SDL_SCANCODE_T)
+pattern SDL_SCANCODE_U :: Scancode
+pattern SDL_SCANCODE_U = (#const SDL_SCANCODE_U)
+pattern SDL_SCANCODE_V :: Scancode
+pattern SDL_SCANCODE_V = (#const SDL_SCANCODE_V)
+pattern SDL_SCANCODE_W :: Scancode
+pattern SDL_SCANCODE_W = (#const SDL_SCANCODE_W)
+pattern SDL_SCANCODE_X :: Scancode
+pattern SDL_SCANCODE_X = (#const SDL_SCANCODE_X)
+pattern SDL_SCANCODE_Y :: Scancode
+pattern SDL_SCANCODE_Y = (#const SDL_SCANCODE_Y)
+pattern SDL_SCANCODE_Z :: Scancode
+pattern SDL_SCANCODE_Z = (#const SDL_SCANCODE_Z)
+pattern SDL_SCANCODE_1 :: Scancode
+pattern SDL_SCANCODE_1 = (#const SDL_SCANCODE_1)
+pattern SDL_SCANCODE_2 :: Scancode
+pattern SDL_SCANCODE_2 = (#const SDL_SCANCODE_2)
+pattern SDL_SCANCODE_3 :: Scancode
+pattern SDL_SCANCODE_3 = (#const SDL_SCANCODE_3)
+pattern SDL_SCANCODE_4 :: Scancode
+pattern SDL_SCANCODE_4 = (#const SDL_SCANCODE_4)
+pattern SDL_SCANCODE_5 :: Scancode
+pattern SDL_SCANCODE_5 = (#const SDL_SCANCODE_5)
+pattern SDL_SCANCODE_6 :: Scancode
+pattern SDL_SCANCODE_6 = (#const SDL_SCANCODE_6)
+pattern SDL_SCANCODE_7 :: Scancode
+pattern SDL_SCANCODE_7 = (#const SDL_SCANCODE_7)
+pattern SDL_SCANCODE_8 :: Scancode
+pattern SDL_SCANCODE_8 = (#const SDL_SCANCODE_8)
+pattern SDL_SCANCODE_9 :: Scancode
+pattern SDL_SCANCODE_9 = (#const SDL_SCANCODE_9)
+pattern SDL_SCANCODE_0 :: Scancode
+pattern SDL_SCANCODE_0 = (#const SDL_SCANCODE_0)
+pattern SDL_SCANCODE_RETURN :: Scancode
+pattern SDL_SCANCODE_RETURN = (#const SDL_SCANCODE_RETURN)
+pattern SDL_SCANCODE_ESCAPE :: Scancode
+pattern SDL_SCANCODE_ESCAPE = (#const SDL_SCANCODE_ESCAPE)
+pattern SDL_SCANCODE_BACKSPACE :: Scancode
+pattern SDL_SCANCODE_BACKSPACE = (#const SDL_SCANCODE_BACKSPACE)
+pattern SDL_SCANCODE_TAB :: Scancode
+pattern SDL_SCANCODE_TAB = (#const SDL_SCANCODE_TAB)
+pattern SDL_SCANCODE_SPACE :: Scancode
+pattern SDL_SCANCODE_SPACE = (#const SDL_SCANCODE_SPACE)
+pattern SDL_SCANCODE_MINUS :: Scancode
+pattern SDL_SCANCODE_MINUS = (#const SDL_SCANCODE_MINUS)
+pattern SDL_SCANCODE_EQUALS :: Scancode
+pattern SDL_SCANCODE_EQUALS = (#const SDL_SCANCODE_EQUALS)
+pattern SDL_SCANCODE_LEFTBRACKET :: Scancode
+pattern SDL_SCANCODE_LEFTBRACKET = (#const SDL_SCANCODE_LEFTBRACKET)
+pattern SDL_SCANCODE_RIGHTBRACKET :: Scancode
+pattern SDL_SCANCODE_RIGHTBRACKET = (#const SDL_SCANCODE_RIGHTBRACKET)
+pattern SDL_SCANCODE_BACKSLASH :: Scancode
+pattern SDL_SCANCODE_BACKSLASH = (#const SDL_SCANCODE_BACKSLASH)
+pattern SDL_SCANCODE_NONUSHASH :: Scancode
+pattern SDL_SCANCODE_NONUSHASH = (#const SDL_SCANCODE_NONUSHASH)
+pattern SDL_SCANCODE_SEMICOLON :: Scancode
+pattern SDL_SCANCODE_SEMICOLON = (#const SDL_SCANCODE_SEMICOLON)
+pattern SDL_SCANCODE_APOSTROPHE :: Scancode
+pattern SDL_SCANCODE_APOSTROPHE = (#const SDL_SCANCODE_APOSTROPHE)
+pattern SDL_SCANCODE_GRAVE :: Scancode
+pattern SDL_SCANCODE_GRAVE = (#const SDL_SCANCODE_GRAVE)
+pattern SDL_SCANCODE_COMMA :: Scancode
+pattern SDL_SCANCODE_COMMA = (#const SDL_SCANCODE_COMMA)
+pattern SDL_SCANCODE_PERIOD :: Scancode
+pattern SDL_SCANCODE_PERIOD = (#const SDL_SCANCODE_PERIOD)
+pattern SDL_SCANCODE_SLASH :: Scancode
+pattern SDL_SCANCODE_SLASH = (#const SDL_SCANCODE_SLASH)
+pattern SDL_SCANCODE_CAPSLOCK :: Scancode
+pattern SDL_SCANCODE_CAPSLOCK = (#const SDL_SCANCODE_CAPSLOCK)
+pattern SDL_SCANCODE_F1 :: Scancode
+pattern SDL_SCANCODE_F1 = (#const SDL_SCANCODE_F1)
+pattern SDL_SCANCODE_F2 :: Scancode
+pattern SDL_SCANCODE_F2 = (#const SDL_SCANCODE_F2)
+pattern SDL_SCANCODE_F3 :: Scancode
+pattern SDL_SCANCODE_F3 = (#const SDL_SCANCODE_F3)
+pattern SDL_SCANCODE_F4 :: Scancode
+pattern SDL_SCANCODE_F4 = (#const SDL_SCANCODE_F4)
+pattern SDL_SCANCODE_F5 :: Scancode
+pattern SDL_SCANCODE_F5 = (#const SDL_SCANCODE_F5)
+pattern SDL_SCANCODE_F6 :: Scancode
+pattern SDL_SCANCODE_F6 = (#const SDL_SCANCODE_F6)
+pattern SDL_SCANCODE_F7 :: Scancode
+pattern SDL_SCANCODE_F7 = (#const SDL_SCANCODE_F7)
+pattern SDL_SCANCODE_F8 :: Scancode
+pattern SDL_SCANCODE_F8 = (#const SDL_SCANCODE_F8)
+pattern SDL_SCANCODE_F9 :: Scancode
+pattern SDL_SCANCODE_F9 = (#const SDL_SCANCODE_F9)
+pattern SDL_SCANCODE_F10 :: Scancode
+pattern SDL_SCANCODE_F10 = (#const SDL_SCANCODE_F10)
+pattern SDL_SCANCODE_F11 :: Scancode
+pattern SDL_SCANCODE_F11 = (#const SDL_SCANCODE_F11)
+pattern SDL_SCANCODE_F12 :: Scancode
+pattern SDL_SCANCODE_F12 = (#const SDL_SCANCODE_F12)
+pattern SDL_SCANCODE_PRINTSCREEN :: Scancode
+pattern SDL_SCANCODE_PRINTSCREEN = (#const SDL_SCANCODE_PRINTSCREEN)
+pattern SDL_SCANCODE_SCROLLLOCK :: Scancode
+pattern SDL_SCANCODE_SCROLLLOCK = (#const SDL_SCANCODE_SCROLLLOCK)
+pattern SDL_SCANCODE_PAUSE :: Scancode
+pattern SDL_SCANCODE_PAUSE = (#const SDL_SCANCODE_PAUSE)
+pattern SDL_SCANCODE_INSERT :: Scancode
+pattern SDL_SCANCODE_INSERT = (#const SDL_SCANCODE_INSERT)
+pattern SDL_SCANCODE_HOME :: Scancode
+pattern SDL_SCANCODE_HOME = (#const SDL_SCANCODE_HOME)
+pattern SDL_SCANCODE_PAGEUP :: Scancode
+pattern SDL_SCANCODE_PAGEUP = (#const SDL_SCANCODE_PAGEUP)
+pattern SDL_SCANCODE_DELETE :: Scancode
+pattern SDL_SCANCODE_DELETE = (#const SDL_SCANCODE_DELETE)
+pattern SDL_SCANCODE_END :: Scancode
+pattern SDL_SCANCODE_END = (#const SDL_SCANCODE_END)
+pattern SDL_SCANCODE_PAGEDOWN :: Scancode
+pattern SDL_SCANCODE_PAGEDOWN = (#const SDL_SCANCODE_PAGEDOWN)
+pattern SDL_SCANCODE_RIGHT :: Scancode
+pattern SDL_SCANCODE_RIGHT = (#const SDL_SCANCODE_RIGHT)
+pattern SDL_SCANCODE_LEFT :: Scancode
+pattern SDL_SCANCODE_LEFT = (#const SDL_SCANCODE_LEFT)
+pattern SDL_SCANCODE_DOWN :: Scancode
+pattern SDL_SCANCODE_DOWN = (#const SDL_SCANCODE_DOWN)
+pattern SDL_SCANCODE_UP :: Scancode
+pattern SDL_SCANCODE_UP = (#const SDL_SCANCODE_UP)
+pattern SDL_SCANCODE_NUMLOCKCLEAR :: Scancode
+pattern SDL_SCANCODE_NUMLOCKCLEAR = (#const SDL_SCANCODE_NUMLOCKCLEAR)
+pattern SDL_SCANCODE_KP_DIVIDE :: Scancode
+pattern SDL_SCANCODE_KP_DIVIDE = (#const SDL_SCANCODE_KP_DIVIDE)
+pattern SDL_SCANCODE_KP_MULTIPLY :: Scancode
+pattern SDL_SCANCODE_KP_MULTIPLY = (#const SDL_SCANCODE_KP_MULTIPLY)
+pattern SDL_SCANCODE_KP_MINUS :: Scancode
+pattern SDL_SCANCODE_KP_MINUS = (#const SDL_SCANCODE_KP_MINUS)
+pattern SDL_SCANCODE_KP_PLUS :: Scancode
+pattern SDL_SCANCODE_KP_PLUS = (#const SDL_SCANCODE_KP_PLUS)
+pattern SDL_SCANCODE_KP_ENTER :: Scancode
+pattern SDL_SCANCODE_KP_ENTER = (#const SDL_SCANCODE_KP_ENTER)
+pattern SDL_SCANCODE_KP_1 :: Scancode
+pattern SDL_SCANCODE_KP_1 = (#const SDL_SCANCODE_KP_1)
+pattern SDL_SCANCODE_KP_2 :: Scancode
+pattern SDL_SCANCODE_KP_2 = (#const SDL_SCANCODE_KP_2)
+pattern SDL_SCANCODE_KP_3 :: Scancode
+pattern SDL_SCANCODE_KP_3 = (#const SDL_SCANCODE_KP_3)
+pattern SDL_SCANCODE_KP_4 :: Scancode
+pattern SDL_SCANCODE_KP_4 = (#const SDL_SCANCODE_KP_4)
+pattern SDL_SCANCODE_KP_5 :: Scancode
+pattern SDL_SCANCODE_KP_5 = (#const SDL_SCANCODE_KP_5)
+pattern SDL_SCANCODE_KP_6 :: Scancode
+pattern SDL_SCANCODE_KP_6 = (#const SDL_SCANCODE_KP_6)
+pattern SDL_SCANCODE_KP_7 :: Scancode
+pattern SDL_SCANCODE_KP_7 = (#const SDL_SCANCODE_KP_7)
+pattern SDL_SCANCODE_KP_8 :: Scancode
+pattern SDL_SCANCODE_KP_8 = (#const SDL_SCANCODE_KP_8)
+pattern SDL_SCANCODE_KP_9 :: Scancode
+pattern SDL_SCANCODE_KP_9 = (#const SDL_SCANCODE_KP_9)
+pattern SDL_SCANCODE_KP_0 :: Scancode
+pattern SDL_SCANCODE_KP_0 = (#const SDL_SCANCODE_KP_0)
+pattern SDL_SCANCODE_KP_PERIOD :: Scancode
+pattern SDL_SCANCODE_KP_PERIOD = (#const SDL_SCANCODE_KP_PERIOD)
+pattern SDL_SCANCODE_NONUSBACKSLASH :: Scancode
+pattern SDL_SCANCODE_NONUSBACKSLASH = (#const SDL_SCANCODE_NONUSBACKSLASH)
+pattern SDL_SCANCODE_APPLICATION :: Scancode
+pattern SDL_SCANCODE_APPLICATION = (#const SDL_SCANCODE_APPLICATION)
+pattern SDL_SCANCODE_POWER :: Scancode
+pattern SDL_SCANCODE_POWER = (#const SDL_SCANCODE_POWER)
+pattern SDL_SCANCODE_KP_EQUALS :: Scancode
+pattern SDL_SCANCODE_KP_EQUALS = (#const SDL_SCANCODE_KP_EQUALS)
+pattern SDL_SCANCODE_F13 :: Scancode
+pattern SDL_SCANCODE_F13 = (#const SDL_SCANCODE_F13)
+pattern SDL_SCANCODE_F14 :: Scancode
+pattern SDL_SCANCODE_F14 = (#const SDL_SCANCODE_F14)
+pattern SDL_SCANCODE_F15 :: Scancode
+pattern SDL_SCANCODE_F15 = (#const SDL_SCANCODE_F15)
+pattern SDL_SCANCODE_F16 :: Scancode
+pattern SDL_SCANCODE_F16 = (#const SDL_SCANCODE_F16)
+pattern SDL_SCANCODE_F17 :: Scancode
+pattern SDL_SCANCODE_F17 = (#const SDL_SCANCODE_F17)
+pattern SDL_SCANCODE_F18 :: Scancode
+pattern SDL_SCANCODE_F18 = (#const SDL_SCANCODE_F18)
+pattern SDL_SCANCODE_F19 :: Scancode
+pattern SDL_SCANCODE_F19 = (#const SDL_SCANCODE_F19)
+pattern SDL_SCANCODE_F20 :: Scancode
+pattern SDL_SCANCODE_F20 = (#const SDL_SCANCODE_F20)
+pattern SDL_SCANCODE_F21 :: Scancode
+pattern SDL_SCANCODE_F21 = (#const SDL_SCANCODE_F21)
+pattern SDL_SCANCODE_F22 :: Scancode
+pattern SDL_SCANCODE_F22 = (#const SDL_SCANCODE_F22)
+pattern SDL_SCANCODE_F23 :: Scancode
+pattern SDL_SCANCODE_F23 = (#const SDL_SCANCODE_F23)
+pattern SDL_SCANCODE_F24 :: Scancode
+pattern SDL_SCANCODE_F24 = (#const SDL_SCANCODE_F24)
+pattern SDL_SCANCODE_EXECUTE :: Scancode
+pattern SDL_SCANCODE_EXECUTE = (#const SDL_SCANCODE_EXECUTE)
+pattern SDL_SCANCODE_HELP :: Scancode
+pattern SDL_SCANCODE_HELP = (#const SDL_SCANCODE_HELP)
+pattern SDL_SCANCODE_MENU :: Scancode
+pattern SDL_SCANCODE_MENU = (#const SDL_SCANCODE_MENU)
+pattern SDL_SCANCODE_SELECT :: Scancode
+pattern SDL_SCANCODE_SELECT = (#const SDL_SCANCODE_SELECT)
+pattern SDL_SCANCODE_STOP :: Scancode
+pattern SDL_SCANCODE_STOP = (#const SDL_SCANCODE_STOP)
+pattern SDL_SCANCODE_AGAIN :: Scancode
+pattern SDL_SCANCODE_AGAIN = (#const SDL_SCANCODE_AGAIN)
+pattern SDL_SCANCODE_UNDO :: Scancode
+pattern SDL_SCANCODE_UNDO = (#const SDL_SCANCODE_UNDO)
+pattern SDL_SCANCODE_CUT :: Scancode
+pattern SDL_SCANCODE_CUT = (#const SDL_SCANCODE_CUT)
+pattern SDL_SCANCODE_COPY :: Scancode
+pattern SDL_SCANCODE_COPY = (#const SDL_SCANCODE_COPY)
+pattern SDL_SCANCODE_PASTE :: Scancode
+pattern SDL_SCANCODE_PASTE = (#const SDL_SCANCODE_PASTE)
+pattern SDL_SCANCODE_FIND :: Scancode
+pattern SDL_SCANCODE_FIND = (#const SDL_SCANCODE_FIND)
+pattern SDL_SCANCODE_MUTE :: Scancode
+pattern SDL_SCANCODE_MUTE = (#const SDL_SCANCODE_MUTE)
+pattern SDL_SCANCODE_VOLUMEUP :: Scancode
+pattern SDL_SCANCODE_VOLUMEUP = (#const SDL_SCANCODE_VOLUMEUP)
+pattern SDL_SCANCODE_VOLUMEDOWN :: Scancode
+pattern SDL_SCANCODE_VOLUMEDOWN = (#const SDL_SCANCODE_VOLUMEDOWN)
+pattern SDL_SCANCODE_KP_COMMA :: Scancode
+pattern SDL_SCANCODE_KP_COMMA = (#const SDL_SCANCODE_KP_COMMA)
+pattern SDL_SCANCODE_KP_EQUALSAS400 :: Scancode
+pattern SDL_SCANCODE_KP_EQUALSAS400 = (#const SDL_SCANCODE_KP_EQUALSAS400)
+pattern SDL_SCANCODE_INTERNATIONAL1 :: Scancode
+pattern SDL_SCANCODE_INTERNATIONAL1 = (#const SDL_SCANCODE_INTERNATIONAL1)
+pattern SDL_SCANCODE_INTERNATIONAL2 :: Scancode
+pattern SDL_SCANCODE_INTERNATIONAL2 = (#const SDL_SCANCODE_INTERNATIONAL2)
+pattern SDL_SCANCODE_INTERNATIONAL3 :: Scancode
+pattern SDL_SCANCODE_INTERNATIONAL3 = (#const SDL_SCANCODE_INTERNATIONAL3)
+pattern SDL_SCANCODE_INTERNATIONAL4 :: Scancode
+pattern SDL_SCANCODE_INTERNATIONAL4 = (#const SDL_SCANCODE_INTERNATIONAL4)
+pattern SDL_SCANCODE_INTERNATIONAL5 :: Scancode
+pattern SDL_SCANCODE_INTERNATIONAL5 = (#const SDL_SCANCODE_INTERNATIONAL5)
+pattern SDL_SCANCODE_INTERNATIONAL6 :: Scancode
+pattern SDL_SCANCODE_INTERNATIONAL6 = (#const SDL_SCANCODE_INTERNATIONAL6)
+pattern SDL_SCANCODE_INTERNATIONAL7 :: Scancode
+pattern SDL_SCANCODE_INTERNATIONAL7 = (#const SDL_SCANCODE_INTERNATIONAL7)
+pattern SDL_SCANCODE_INTERNATIONAL8 :: Scancode
+pattern SDL_SCANCODE_INTERNATIONAL8 = (#const SDL_SCANCODE_INTERNATIONAL8)
+pattern SDL_SCANCODE_INTERNATIONAL9 :: Scancode
+pattern SDL_SCANCODE_INTERNATIONAL9 = (#const SDL_SCANCODE_INTERNATIONAL9)
+pattern SDL_SCANCODE_LANG1 :: Scancode
+pattern SDL_SCANCODE_LANG1 = (#const SDL_SCANCODE_LANG1)
+pattern SDL_SCANCODE_LANG2 :: Scancode
+pattern SDL_SCANCODE_LANG2 = (#const SDL_SCANCODE_LANG2)
+pattern SDL_SCANCODE_LANG3 :: Scancode
+pattern SDL_SCANCODE_LANG3 = (#const SDL_SCANCODE_LANG3)
+pattern SDL_SCANCODE_LANG4 :: Scancode
+pattern SDL_SCANCODE_LANG4 = (#const SDL_SCANCODE_LANG4)
+pattern SDL_SCANCODE_LANG5 :: Scancode
+pattern SDL_SCANCODE_LANG5 = (#const SDL_SCANCODE_LANG5)
+pattern SDL_SCANCODE_LANG6 :: Scancode
+pattern SDL_SCANCODE_LANG6 = (#const SDL_SCANCODE_LANG6)
+pattern SDL_SCANCODE_LANG7 :: Scancode
+pattern SDL_SCANCODE_LANG7 = (#const SDL_SCANCODE_LANG7)
+pattern SDL_SCANCODE_LANG8 :: Scancode
+pattern SDL_SCANCODE_LANG8 = (#const SDL_SCANCODE_LANG8)
+pattern SDL_SCANCODE_LANG9 :: Scancode
+pattern SDL_SCANCODE_LANG9 = (#const SDL_SCANCODE_LANG9)
+pattern SDL_SCANCODE_ALTERASE :: Scancode
+pattern SDL_SCANCODE_ALTERASE = (#const SDL_SCANCODE_ALTERASE)
+pattern SDL_SCANCODE_SYSREQ :: Scancode
+pattern SDL_SCANCODE_SYSREQ = (#const SDL_SCANCODE_SYSREQ)
+pattern SDL_SCANCODE_CANCEL :: Scancode
+pattern SDL_SCANCODE_CANCEL = (#const SDL_SCANCODE_CANCEL)
+pattern SDL_SCANCODE_CLEAR :: Scancode
+pattern SDL_SCANCODE_CLEAR = (#const SDL_SCANCODE_CLEAR)
+pattern SDL_SCANCODE_PRIOR :: Scancode
+pattern SDL_SCANCODE_PRIOR = (#const SDL_SCANCODE_PRIOR)
+pattern SDL_SCANCODE_RETURN2 :: Scancode
+pattern SDL_SCANCODE_RETURN2 = (#const SDL_SCANCODE_RETURN2)
+pattern SDL_SCANCODE_SEPARATOR :: Scancode
+pattern SDL_SCANCODE_SEPARATOR = (#const SDL_SCANCODE_SEPARATOR)
+pattern SDL_SCANCODE_OUT :: Scancode
+pattern SDL_SCANCODE_OUT = (#const SDL_SCANCODE_OUT)
+pattern SDL_SCANCODE_OPER :: Scancode
+pattern SDL_SCANCODE_OPER = (#const SDL_SCANCODE_OPER)
+pattern SDL_SCANCODE_CLEARAGAIN :: Scancode
+pattern SDL_SCANCODE_CLEARAGAIN = (#const SDL_SCANCODE_CLEARAGAIN)
+pattern SDL_SCANCODE_CRSEL :: Scancode
+pattern SDL_SCANCODE_CRSEL = (#const SDL_SCANCODE_CRSEL)
+pattern SDL_SCANCODE_EXSEL :: Scancode
+pattern SDL_SCANCODE_EXSEL = (#const SDL_SCANCODE_EXSEL)
+pattern SDL_SCANCODE_KP_00 :: Scancode
+pattern SDL_SCANCODE_KP_00 = (#const SDL_SCANCODE_KP_00)
+pattern SDL_SCANCODE_KP_000 :: Scancode
+pattern SDL_SCANCODE_KP_000 = (#const SDL_SCANCODE_KP_000)
+pattern SDL_SCANCODE_THOUSANDSSEPARATOR :: Scancode
+pattern SDL_SCANCODE_THOUSANDSSEPARATOR = (#const SDL_SCANCODE_THOUSANDSSEPARATOR)
+pattern SDL_SCANCODE_DECIMALSEPARATOR :: Scancode
+pattern SDL_SCANCODE_DECIMALSEPARATOR = (#const SDL_SCANCODE_DECIMALSEPARATOR)
+pattern SDL_SCANCODE_CURRENCYUNIT :: Scancode
+pattern SDL_SCANCODE_CURRENCYUNIT = (#const SDL_SCANCODE_CURRENCYUNIT)
+pattern SDL_SCANCODE_CURRENCYSUBUNIT :: Scancode
+pattern SDL_SCANCODE_CURRENCYSUBUNIT = (#const SDL_SCANCODE_CURRENCYSUBUNIT)
+pattern SDL_SCANCODE_KP_LEFTPAREN :: Scancode
+pattern SDL_SCANCODE_KP_LEFTPAREN = (#const SDL_SCANCODE_KP_LEFTPAREN)
+pattern SDL_SCANCODE_KP_RIGHTPAREN :: Scancode
+pattern SDL_SCANCODE_KP_RIGHTPAREN = (#const SDL_SCANCODE_KP_RIGHTPAREN)
+pattern SDL_SCANCODE_KP_LEFTBRACE :: Scancode
+pattern SDL_SCANCODE_KP_LEFTBRACE = (#const SDL_SCANCODE_KP_LEFTBRACE)
+pattern SDL_SCANCODE_KP_RIGHTBRACE :: Scancode
+pattern SDL_SCANCODE_KP_RIGHTBRACE = (#const SDL_SCANCODE_KP_RIGHTBRACE)
+pattern SDL_SCANCODE_KP_TAB :: Scancode
+pattern SDL_SCANCODE_KP_TAB = (#const SDL_SCANCODE_KP_TAB)
+pattern SDL_SCANCODE_KP_BACKSPACE :: Scancode
+pattern SDL_SCANCODE_KP_BACKSPACE = (#const SDL_SCANCODE_KP_BACKSPACE)
+pattern SDL_SCANCODE_KP_A :: Scancode
+pattern SDL_SCANCODE_KP_A = (#const SDL_SCANCODE_KP_A)
+pattern SDL_SCANCODE_KP_B :: Scancode
+pattern SDL_SCANCODE_KP_B = (#const SDL_SCANCODE_KP_B)
+pattern SDL_SCANCODE_KP_C :: Scancode
+pattern SDL_SCANCODE_KP_C = (#const SDL_SCANCODE_KP_C)
+pattern SDL_SCANCODE_KP_D :: Scancode
+pattern SDL_SCANCODE_KP_D = (#const SDL_SCANCODE_KP_D)
+pattern SDL_SCANCODE_KP_E :: Scancode
+pattern SDL_SCANCODE_KP_E = (#const SDL_SCANCODE_KP_E)
+pattern SDL_SCANCODE_KP_F :: Scancode
+pattern SDL_SCANCODE_KP_F = (#const SDL_SCANCODE_KP_F)
+pattern SDL_SCANCODE_KP_XOR :: Scancode
+pattern SDL_SCANCODE_KP_XOR = (#const SDL_SCANCODE_KP_XOR)
+pattern SDL_SCANCODE_KP_POWER :: Scancode
+pattern SDL_SCANCODE_KP_POWER = (#const SDL_SCANCODE_KP_POWER)
+pattern SDL_SCANCODE_KP_PERCENT :: Scancode
+pattern SDL_SCANCODE_KP_PERCENT = (#const SDL_SCANCODE_KP_PERCENT)
+pattern SDL_SCANCODE_KP_LESS :: Scancode
+pattern SDL_SCANCODE_KP_LESS = (#const SDL_SCANCODE_KP_LESS)
+pattern SDL_SCANCODE_KP_GREATER :: Scancode
+pattern SDL_SCANCODE_KP_GREATER = (#const SDL_SCANCODE_KP_GREATER)
+pattern SDL_SCANCODE_KP_AMPERSAND :: Scancode
+pattern SDL_SCANCODE_KP_AMPERSAND = (#const SDL_SCANCODE_KP_AMPERSAND)
+pattern SDL_SCANCODE_KP_DBLAMPERSAND :: Scancode
+pattern SDL_SCANCODE_KP_DBLAMPERSAND = (#const SDL_SCANCODE_KP_DBLAMPERSAND)
+pattern SDL_SCANCODE_KP_VERTICALBAR :: Scancode
+pattern SDL_SCANCODE_KP_VERTICALBAR = (#const SDL_SCANCODE_KP_VERTICALBAR)
+pattern SDL_SCANCODE_KP_DBLVERTICALBAR :: Scancode
+pattern SDL_SCANCODE_KP_DBLVERTICALBAR = (#const SDL_SCANCODE_KP_DBLVERTICALBAR)
+pattern SDL_SCANCODE_KP_COLON :: Scancode
+pattern SDL_SCANCODE_KP_COLON = (#const SDL_SCANCODE_KP_COLON)
+pattern SDL_SCANCODE_KP_HASH :: Scancode
+pattern SDL_SCANCODE_KP_HASH = (#const SDL_SCANCODE_KP_HASH)
+pattern SDL_SCANCODE_KP_SPACE :: Scancode
+pattern SDL_SCANCODE_KP_SPACE = (#const SDL_SCANCODE_KP_SPACE)
+pattern SDL_SCANCODE_KP_AT :: Scancode
+pattern SDL_SCANCODE_KP_AT = (#const SDL_SCANCODE_KP_AT)
+pattern SDL_SCANCODE_KP_EXCLAM :: Scancode
+pattern SDL_SCANCODE_KP_EXCLAM = (#const SDL_SCANCODE_KP_EXCLAM)
+pattern SDL_SCANCODE_KP_MEMSTORE :: Scancode
+pattern SDL_SCANCODE_KP_MEMSTORE = (#const SDL_SCANCODE_KP_MEMSTORE)
+pattern SDL_SCANCODE_KP_MEMRECALL :: Scancode
+pattern SDL_SCANCODE_KP_MEMRECALL = (#const SDL_SCANCODE_KP_MEMRECALL)
+pattern SDL_SCANCODE_KP_MEMCLEAR :: Scancode
+pattern SDL_SCANCODE_KP_MEMCLEAR = (#const SDL_SCANCODE_KP_MEMCLEAR)
+pattern SDL_SCANCODE_KP_MEMADD :: Scancode
+pattern SDL_SCANCODE_KP_MEMADD = (#const SDL_SCANCODE_KP_MEMADD)
+pattern SDL_SCANCODE_KP_MEMSUBTRACT :: Scancode
+pattern SDL_SCANCODE_KP_MEMSUBTRACT = (#const SDL_SCANCODE_KP_MEMSUBTRACT)
+pattern SDL_SCANCODE_KP_MEMMULTIPLY :: Scancode
+pattern SDL_SCANCODE_KP_MEMMULTIPLY = (#const SDL_SCANCODE_KP_MEMMULTIPLY)
+pattern SDL_SCANCODE_KP_MEMDIVIDE :: Scancode
+pattern SDL_SCANCODE_KP_MEMDIVIDE = (#const SDL_SCANCODE_KP_MEMDIVIDE)
+pattern SDL_SCANCODE_KP_PLUSMINUS :: Scancode
+pattern SDL_SCANCODE_KP_PLUSMINUS = (#const SDL_SCANCODE_KP_PLUSMINUS)
+pattern SDL_SCANCODE_KP_CLEAR :: Scancode
+pattern SDL_SCANCODE_KP_CLEAR = (#const SDL_SCANCODE_KP_CLEAR)
+pattern SDL_SCANCODE_KP_CLEARENTRY :: Scancode
+pattern SDL_SCANCODE_KP_CLEARENTRY = (#const SDL_SCANCODE_KP_CLEARENTRY)
+pattern SDL_SCANCODE_KP_BINARY :: Scancode
+pattern SDL_SCANCODE_KP_BINARY = (#const SDL_SCANCODE_KP_BINARY)
+pattern SDL_SCANCODE_KP_OCTAL :: Scancode
+pattern SDL_SCANCODE_KP_OCTAL = (#const SDL_SCANCODE_KP_OCTAL)
+pattern SDL_SCANCODE_KP_DECIMAL :: Scancode
+pattern SDL_SCANCODE_KP_DECIMAL = (#const SDL_SCANCODE_KP_DECIMAL)
+pattern SDL_SCANCODE_KP_HEXADECIMAL :: Scancode
+pattern SDL_SCANCODE_KP_HEXADECIMAL = (#const SDL_SCANCODE_KP_HEXADECIMAL)
+pattern SDL_SCANCODE_LCTRL :: Scancode
+pattern SDL_SCANCODE_LCTRL = (#const SDL_SCANCODE_LCTRL)
+pattern SDL_SCANCODE_LSHIFT :: Scancode
+pattern SDL_SCANCODE_LSHIFT = (#const SDL_SCANCODE_LSHIFT)
+pattern SDL_SCANCODE_LALT :: Scancode
+pattern SDL_SCANCODE_LALT = (#const SDL_SCANCODE_LALT)
+pattern SDL_SCANCODE_LGUI :: Scancode
+pattern SDL_SCANCODE_LGUI = (#const SDL_SCANCODE_LGUI)
+pattern SDL_SCANCODE_RCTRL :: Scancode
+pattern SDL_SCANCODE_RCTRL = (#const SDL_SCANCODE_RCTRL)
+pattern SDL_SCANCODE_RSHIFT :: Scancode
+pattern SDL_SCANCODE_RSHIFT = (#const SDL_SCANCODE_RSHIFT)
+pattern SDL_SCANCODE_RALT :: Scancode
+pattern SDL_SCANCODE_RALT = (#const SDL_SCANCODE_RALT)
+pattern SDL_SCANCODE_RGUI :: Scancode
+pattern SDL_SCANCODE_RGUI = (#const SDL_SCANCODE_RGUI)
+pattern SDL_SCANCODE_MODE :: Scancode
+pattern SDL_SCANCODE_MODE = (#const SDL_SCANCODE_MODE)
+pattern SDL_SCANCODE_AUDIONEXT :: Scancode
+pattern SDL_SCANCODE_AUDIONEXT = (#const SDL_SCANCODE_AUDIONEXT)
+pattern SDL_SCANCODE_AUDIOPREV :: Scancode
+pattern SDL_SCANCODE_AUDIOPREV = (#const SDL_SCANCODE_AUDIOPREV)
+pattern SDL_SCANCODE_AUDIOSTOP :: Scancode
+pattern SDL_SCANCODE_AUDIOSTOP = (#const SDL_SCANCODE_AUDIOSTOP)
+pattern SDL_SCANCODE_AUDIOPLAY :: Scancode
+pattern SDL_SCANCODE_AUDIOPLAY = (#const SDL_SCANCODE_AUDIOPLAY)
+pattern SDL_SCANCODE_AUDIOMUTE :: Scancode
+pattern SDL_SCANCODE_AUDIOMUTE = (#const SDL_SCANCODE_AUDIOMUTE)
+pattern SDL_SCANCODE_MEDIASELECT :: Scancode
+pattern SDL_SCANCODE_MEDIASELECT = (#const SDL_SCANCODE_MEDIASELECT)
+pattern SDL_SCANCODE_WWW :: Scancode
+pattern SDL_SCANCODE_WWW = (#const SDL_SCANCODE_WWW)
+pattern SDL_SCANCODE_MAIL :: Scancode
+pattern SDL_SCANCODE_MAIL = (#const SDL_SCANCODE_MAIL)
+pattern SDL_SCANCODE_CALCULATOR :: Scancode
+pattern SDL_SCANCODE_CALCULATOR = (#const SDL_SCANCODE_CALCULATOR)
+pattern SDL_SCANCODE_COMPUTER :: Scancode
+pattern SDL_SCANCODE_COMPUTER = (#const SDL_SCANCODE_COMPUTER)
+pattern SDL_SCANCODE_AC_SEARCH :: Scancode
+pattern SDL_SCANCODE_AC_SEARCH = (#const SDL_SCANCODE_AC_SEARCH)
+pattern SDL_SCANCODE_AC_HOME :: Scancode
+pattern SDL_SCANCODE_AC_HOME = (#const SDL_SCANCODE_AC_HOME)
+pattern SDL_SCANCODE_AC_BACK :: Scancode
+pattern SDL_SCANCODE_AC_BACK = (#const SDL_SCANCODE_AC_BACK)
+pattern SDL_SCANCODE_AC_FORWARD :: Scancode
+pattern SDL_SCANCODE_AC_FORWARD = (#const SDL_SCANCODE_AC_FORWARD)
+pattern SDL_SCANCODE_AC_STOP :: Scancode
+pattern SDL_SCANCODE_AC_STOP = (#const SDL_SCANCODE_AC_STOP)
+pattern SDL_SCANCODE_AC_REFRESH :: Scancode
+pattern SDL_SCANCODE_AC_REFRESH = (#const SDL_SCANCODE_AC_REFRESH)
+pattern SDL_SCANCODE_AC_BOOKMARKS :: Scancode
+pattern SDL_SCANCODE_AC_BOOKMARKS = (#const SDL_SCANCODE_AC_BOOKMARKS)
+pattern SDL_SCANCODE_BRIGHTNESSDOWN :: Scancode
+pattern SDL_SCANCODE_BRIGHTNESSDOWN = (#const SDL_SCANCODE_BRIGHTNESSDOWN)
+pattern SDL_SCANCODE_BRIGHTNESSUP :: Scancode
+pattern SDL_SCANCODE_BRIGHTNESSUP = (#const SDL_SCANCODE_BRIGHTNESSUP)
+pattern SDL_SCANCODE_DISPLAYSWITCH :: Scancode
+pattern SDL_SCANCODE_DISPLAYSWITCH = (#const SDL_SCANCODE_DISPLAYSWITCH)
+pattern SDL_SCANCODE_KBDILLUMTOGGLE :: Scancode
+pattern SDL_SCANCODE_KBDILLUMTOGGLE = (#const SDL_SCANCODE_KBDILLUMTOGGLE)
+pattern SDL_SCANCODE_KBDILLUMDOWN :: Scancode
+pattern SDL_SCANCODE_KBDILLUMDOWN = (#const SDL_SCANCODE_KBDILLUMDOWN)
+pattern SDL_SCANCODE_KBDILLUMUP :: Scancode
+pattern SDL_SCANCODE_KBDILLUMUP = (#const SDL_SCANCODE_KBDILLUMUP)
+pattern SDL_SCANCODE_EJECT :: Scancode
+pattern SDL_SCANCODE_EJECT = (#const SDL_SCANCODE_EJECT)
+pattern SDL_SCANCODE_SLEEP :: Scancode
+pattern SDL_SCANCODE_SLEEP = (#const SDL_SCANCODE_SLEEP)
+pattern SDL_SCANCODE_APP1 :: Scancode
+pattern SDL_SCANCODE_APP1 = (#const SDL_SCANCODE_APP1)
+pattern SDL_SCANCODE_APP2 :: Scancode
+pattern SDL_SCANCODE_APP2 = (#const SDL_SCANCODE_APP2)
+pattern SDL_NUM_SCANCODES :: Scancode
+pattern SDL_NUM_SCANCODES = (#const SDL_NUM_SCANCODES)
 
-pattern SDL_SYSTEM_CURSOR_ARROW = (#const SDL_SYSTEM_CURSOR_ARROW) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_IBEAM = (#const SDL_SYSTEM_CURSOR_IBEAM) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_WAIT = (#const SDL_SYSTEM_CURSOR_WAIT) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_CROSSHAIR = (#const SDL_SYSTEM_CURSOR_CROSSHAIR) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_WAITARROW = (#const SDL_SYSTEM_CURSOR_WAITARROW) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_SIZENWSE = (#const SDL_SYSTEM_CURSOR_SIZENWSE) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_SIZENESW = (#const SDL_SYSTEM_CURSOR_SIZENESW) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_SIZEWE = (#const SDL_SYSTEM_CURSOR_SIZEWE) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_SIZENS = (#const SDL_SYSTEM_CURSOR_SIZENS) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_SIZEALL = (#const SDL_SYSTEM_CURSOR_SIZEALL) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_NO = (#const SDL_SYSTEM_CURSOR_NO) :: SystemCursor
-pattern SDL_SYSTEM_CURSOR_HAND = (#const SDL_SYSTEM_CURSOR_HAND) :: SystemCursor
-pattern SDL_NUM_SYSTEM_CURSORS = (#const SDL_NUM_SYSTEM_CURSORS) :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_ARROW :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_ARROW = (#const SDL_SYSTEM_CURSOR_ARROW)
+pattern SDL_SYSTEM_CURSOR_IBEAM :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_IBEAM = (#const SDL_SYSTEM_CURSOR_IBEAM)
+pattern SDL_SYSTEM_CURSOR_WAIT :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_WAIT = (#const SDL_SYSTEM_CURSOR_WAIT)
+pattern SDL_SYSTEM_CURSOR_CROSSHAIR :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_CROSSHAIR = (#const SDL_SYSTEM_CURSOR_CROSSHAIR)
+pattern SDL_SYSTEM_CURSOR_WAITARROW :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_WAITARROW = (#const SDL_SYSTEM_CURSOR_WAITARROW)
+pattern SDL_SYSTEM_CURSOR_SIZENWSE :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_SIZENWSE = (#const SDL_SYSTEM_CURSOR_SIZENWSE)
+pattern SDL_SYSTEM_CURSOR_SIZENESW :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_SIZENESW = (#const SDL_SYSTEM_CURSOR_SIZENESW)
+pattern SDL_SYSTEM_CURSOR_SIZEWE :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_SIZEWE = (#const SDL_SYSTEM_CURSOR_SIZEWE)
+pattern SDL_SYSTEM_CURSOR_SIZENS :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_SIZENS = (#const SDL_SYSTEM_CURSOR_SIZENS)
+pattern SDL_SYSTEM_CURSOR_SIZEALL :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_SIZEALL = (#const SDL_SYSTEM_CURSOR_SIZEALL)
+pattern SDL_SYSTEM_CURSOR_NO :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_NO = (#const SDL_SYSTEM_CURSOR_NO)
+pattern SDL_SYSTEM_CURSOR_HAND :: SystemCursor
+pattern SDL_SYSTEM_CURSOR_HAND = (#const SDL_SYSTEM_CURSOR_HAND)
+pattern SDL_NUM_SYSTEM_CURSORS :: SystemCursor
+pattern SDL_NUM_SYSTEM_CURSORS = (#const SDL_NUM_SYSTEM_CURSORS)
 
-pattern SDL_THREAD_PRIORITY_LOW = (#const SDL_THREAD_PRIORITY_LOW) :: ThreadPriority
-pattern SDL_THREAD_PRIORITY_NORMAL = (#const SDL_THREAD_PRIORITY_NORMAL) :: ThreadPriority
-pattern SDL_THREAD_PRIORITY_HIGH = (#const SDL_THREAD_PRIORITY_HIGH) :: ThreadPriority
+pattern SDL_THREAD_PRIORITY_LOW :: ThreadPriority
+pattern SDL_THREAD_PRIORITY_LOW = (#const SDL_THREAD_PRIORITY_LOW)
+pattern SDL_THREAD_PRIORITY_NORMAL :: ThreadPriority
+pattern SDL_THREAD_PRIORITY_NORMAL = (#const SDL_THREAD_PRIORITY_NORMAL)
+pattern SDL_THREAD_PRIORITY_HIGH :: ThreadPriority
+pattern SDL_THREAD_PRIORITY_HIGH = (#const SDL_THREAD_PRIORITY_HIGH)
 
+pattern SDL_AUDIO_ALLOW_FREQUENCY_CHANGE :: forall a. (Num a, Eq a) => a
 pattern SDL_AUDIO_ALLOW_FREQUENCY_CHANGE = (#const SDL_AUDIO_ALLOW_FREQUENCY_CHANGE)
+pattern SDL_AUDIO_ALLOW_FORMAT_CHANGE :: forall a. (Num a, Eq a) => a
 pattern SDL_AUDIO_ALLOW_FORMAT_CHANGE = (#const SDL_AUDIO_ALLOW_FORMAT_CHANGE)
+pattern SDL_AUDIO_ALLOW_CHANNELS_CHANGE :: forall a. (Num a, Eq a) => a
 pattern SDL_AUDIO_ALLOW_CHANNELS_CHANGE = (#const SDL_AUDIO_ALLOW_CHANNELS_CHANGE)
+pattern SDL_AUDIO_ALLOW_ANY_CHANGE :: forall a. (Num a, Eq a) => a
 pattern SDL_AUDIO_ALLOW_ANY_CHANGE = (#const SDL_AUDIO_ALLOW_ANY_CHANGE)
 
+pattern SDL_BUTTON_LEFT :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_LEFT = (#const SDL_BUTTON_LEFT)
+pattern SDL_BUTTON_MIDDLE :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_MIDDLE = (#const SDL_BUTTON_MIDDLE)
+pattern SDL_BUTTON_RIGHT :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_RIGHT = (#const SDL_BUTTON_RIGHT)
+pattern SDL_BUTTON_X1 :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_X1 = (#const SDL_BUTTON_X1)
+pattern SDL_BUTTON_X2 :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_X2 = (#const SDL_BUTTON_X2)
+pattern SDL_BUTTON_LMASK :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_LMASK = (#const SDL_BUTTON_LMASK)
+pattern SDL_BUTTON_MMASK :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_MMASK = (#const SDL_BUTTON_MMASK)
+pattern SDL_BUTTON_RMASK :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_RMASK = (#const SDL_BUTTON_RMASK)
+pattern SDL_BUTTON_X1MASK :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_X1MASK = (#const SDL_BUTTON_X1MASK)
+pattern SDL_BUTTON_X2MASK :: forall a. (Num a, Eq a) => a
 pattern SDL_BUTTON_X2MASK = (#const SDL_BUTTON_X2MASK)
 
+pattern SDL_FIRSTEVENT :: forall a. (Num a, Eq a) => a
 pattern SDL_FIRSTEVENT = (#const SDL_FIRSTEVENT)
+pattern SDL_QUIT :: forall a. (Num a, Eq a) => a
 pattern SDL_QUIT = (#const SDL_QUIT)
+pattern SDL_APP_TERMINATING :: forall a. (Num a, Eq a) => a
 pattern SDL_APP_TERMINATING = (#const SDL_APP_TERMINATING)
+pattern SDL_APP_LOWMEMORY :: forall a. (Num a, Eq a) => a
 pattern SDL_APP_LOWMEMORY = (#const SDL_APP_LOWMEMORY)
+pattern SDL_APP_WILLENTERBACKGROUND :: forall a. (Num a, Eq a) => a
 pattern SDL_APP_WILLENTERBACKGROUND = (#const SDL_APP_WILLENTERBACKGROUND)
+pattern SDL_APP_DIDENTERBACKGROUND :: forall a. (Num a, Eq a) => a
 pattern SDL_APP_DIDENTERBACKGROUND = (#const SDL_APP_DIDENTERBACKGROUND)
+pattern SDL_APP_WILLENTERFOREGROUND :: forall a. (Num a, Eq a) => a
 pattern SDL_APP_WILLENTERFOREGROUND = (#const SDL_APP_WILLENTERFOREGROUND)
+pattern SDL_APP_DIDENTERFOREGROUND :: forall a. (Num a, Eq a) => a
 pattern SDL_APP_DIDENTERFOREGROUND = (#const SDL_APP_DIDENTERFOREGROUND)
+pattern SDL_WINDOWEVENT :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT = (#const SDL_WINDOWEVENT)
+pattern SDL_SYSWMEVENT :: forall a. (Num a, Eq a) => a
 pattern SDL_SYSWMEVENT = (#const SDL_SYSWMEVENT)
+pattern SDL_KEYDOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_KEYDOWN = (#const SDL_KEYDOWN)
+pattern SDL_KEYUP :: forall a. (Num a, Eq a) => a
 pattern SDL_KEYUP = (#const SDL_KEYUP)
+pattern SDL_TEXTEDITING :: forall a. (Num a, Eq a) => a
 pattern SDL_TEXTEDITING = (#const SDL_TEXTEDITING)
+pattern SDL_TEXTINPUT :: forall a. (Num a, Eq a) => a
 pattern SDL_TEXTINPUT = (#const SDL_TEXTINPUT)
+pattern SDL_MOUSEMOTION :: forall a. (Num a, Eq a) => a
 pattern SDL_MOUSEMOTION = (#const SDL_MOUSEMOTION)
+pattern SDL_MOUSEBUTTONDOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_MOUSEBUTTONDOWN = (#const SDL_MOUSEBUTTONDOWN)
+pattern SDL_MOUSEBUTTONUP :: forall a. (Num a, Eq a) => a
 pattern SDL_MOUSEBUTTONUP = (#const SDL_MOUSEBUTTONUP)
+pattern SDL_MOUSEWHEEL :: forall a. (Num a, Eq a) => a
 pattern SDL_MOUSEWHEEL = (#const SDL_MOUSEWHEEL)
+pattern SDL_JOYAXISMOTION :: forall a. (Num a, Eq a) => a
 pattern SDL_JOYAXISMOTION = (#const SDL_JOYAXISMOTION)
+pattern SDL_JOYBALLMOTION :: forall a. (Num a, Eq a) => a
 pattern SDL_JOYBALLMOTION = (#const SDL_JOYBALLMOTION)
+pattern SDL_JOYHATMOTION :: forall a. (Num a, Eq a) => a
 pattern SDL_JOYHATMOTION = (#const SDL_JOYHATMOTION)
+pattern SDL_JOYBUTTONDOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_JOYBUTTONDOWN = (#const SDL_JOYBUTTONDOWN)
+pattern SDL_JOYBUTTONUP :: forall a. (Num a, Eq a) => a
 pattern SDL_JOYBUTTONUP = (#const SDL_JOYBUTTONUP)
+pattern SDL_JOYDEVICEADDED :: forall a. (Num a, Eq a) => a
 pattern SDL_JOYDEVICEADDED = (#const SDL_JOYDEVICEADDED)
+pattern SDL_JOYDEVICEREMOVED :: forall a. (Num a, Eq a) => a
 pattern SDL_JOYDEVICEREMOVED = (#const SDL_JOYDEVICEREMOVED)
+pattern SDL_CONTROLLERAXISMOTION :: forall a. (Num a, Eq a) => a
 pattern SDL_CONTROLLERAXISMOTION = (#const SDL_CONTROLLERAXISMOTION)
+pattern SDL_CONTROLLERBUTTONDOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_CONTROLLERBUTTONDOWN = (#const SDL_CONTROLLERBUTTONDOWN)
+pattern SDL_CONTROLLERBUTTONUP :: forall a. (Num a, Eq a) => a
 pattern SDL_CONTROLLERBUTTONUP = (#const SDL_CONTROLLERBUTTONUP)
+pattern SDL_CONTROLLERDEVICEADDED :: forall a. (Num a, Eq a) => a
 pattern SDL_CONTROLLERDEVICEADDED = (#const SDL_CONTROLLERDEVICEADDED)
+pattern SDL_CONTROLLERDEVICEREMOVED :: forall a. (Num a, Eq a) => a
 pattern SDL_CONTROLLERDEVICEREMOVED = (#const SDL_CONTROLLERDEVICEREMOVED)
+pattern SDL_CONTROLLERDEVICEREMAPPED :: forall a. (Num a, Eq a) => a
 pattern SDL_CONTROLLERDEVICEREMAPPED = (#const SDL_CONTROLLERDEVICEREMAPPED)
+pattern SDL_FINGERDOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_FINGERDOWN = (#const SDL_FINGERDOWN)
+pattern SDL_FINGERUP :: forall a. (Num a, Eq a) => a
 pattern SDL_FINGERUP = (#const SDL_FINGERUP)
+pattern SDL_FINGERMOTION :: forall a. (Num a, Eq a) => a
 pattern SDL_FINGERMOTION = (#const SDL_FINGERMOTION)
+pattern SDL_DOLLARGESTURE :: forall a. (Num a, Eq a) => a
 pattern SDL_DOLLARGESTURE = (#const SDL_DOLLARGESTURE)
+pattern SDL_DOLLARRECORD :: forall a. (Num a, Eq a) => a
 pattern SDL_DOLLARRECORD = (#const SDL_DOLLARRECORD)
+pattern SDL_MULTIGESTURE :: forall a. (Num a, Eq a) => a
 pattern SDL_MULTIGESTURE = (#const SDL_MULTIGESTURE)
+pattern SDL_CLIPBOARDUPDATE :: forall a. (Num a, Eq a) => a
 pattern SDL_CLIPBOARDUPDATE = (#const SDL_CLIPBOARDUPDATE)
+pattern SDL_DROPFILE :: forall a. (Num a, Eq a) => a
 pattern SDL_DROPFILE = (#const SDL_DROPFILE)
+pattern SDL_USEREVENT :: forall a. (Num a, Eq a) => a
 pattern SDL_USEREVENT = (#const SDL_USEREVENT)
+pattern SDL_LASTEVENT :: forall a. (Num a, Eq a) => a
 pattern SDL_LASTEVENT = (#const SDL_LASTEVENT)
 
+pattern SDL_HAT_CENTERED :: forall a. (Num a, Eq a) => a
 pattern SDL_HAT_CENTERED = (#const SDL_HAT_CENTERED)
+pattern SDL_HAT_UP :: forall a. (Num a, Eq a) => a
 pattern SDL_HAT_UP = (#const SDL_HAT_UP)
+pattern SDL_HAT_RIGHT :: forall a. (Num a, Eq a) => a
 pattern SDL_HAT_RIGHT = (#const SDL_HAT_RIGHT)
+pattern SDL_HAT_DOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_HAT_DOWN = (#const SDL_HAT_DOWN)
+pattern SDL_HAT_LEFT :: forall a. (Num a, Eq a) => a
 pattern SDL_HAT_LEFT = (#const SDL_HAT_LEFT)
+pattern SDL_HAT_RIGHTUP :: forall a. (Num a, Eq a) => a
 pattern SDL_HAT_RIGHTUP = (#const SDL_HAT_RIGHTUP)
+pattern SDL_HAT_RIGHTDOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_HAT_RIGHTDOWN = (#const SDL_HAT_RIGHTDOWN)
+pattern SDL_HAT_LEFTUP :: forall a. (Num a, Eq a) => a
 pattern SDL_HAT_LEFTUP = (#const SDL_HAT_LEFTUP)
+pattern SDL_HAT_LEFTDOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_HAT_LEFTDOWN = (#const SDL_HAT_LEFTDOWN)
 
+pattern SDL_PRESSED :: forall a. (Num a, Eq a) => a
 pattern SDL_PRESSED = (#const SDL_PRESSED)
+pattern SDL_RELEASED :: forall a. (Num a, Eq a) => a
 pattern SDL_RELEASED = (#const SDL_RELEASED)
 
+pattern SDL_LOG_CATEGORY_APPLICATION :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_APPLICATION = (#const SDL_LOG_CATEGORY_APPLICATION)
+pattern SDL_LOG_CATEGORY_ERROR :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_ERROR = (#const SDL_LOG_CATEGORY_ERROR)
+pattern SDL_LOG_CATEGORY_ASSERT :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_ASSERT = (#const SDL_LOG_CATEGORY_ASSERT)
+pattern SDL_LOG_CATEGORY_SYSTEM :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_SYSTEM = (#const SDL_LOG_CATEGORY_SYSTEM)
+pattern SDL_LOG_CATEGORY_AUDIO :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_AUDIO = (#const SDL_LOG_CATEGORY_AUDIO)
+pattern SDL_LOG_CATEGORY_VIDEO :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_VIDEO = (#const SDL_LOG_CATEGORY_VIDEO)
+pattern SDL_LOG_CATEGORY_RENDER :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_RENDER = (#const SDL_LOG_CATEGORY_RENDER)
+pattern SDL_LOG_CATEGORY_INPUT :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_INPUT = (#const SDL_LOG_CATEGORY_INPUT)
+pattern SDL_LOG_CATEGORY_TEST :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_TEST = (#const SDL_LOG_CATEGORY_TEST)
+pattern SDL_LOG_CATEGORY_CUSTOM :: forall a. (Num a, Eq a) => a
 pattern SDL_LOG_CATEGORY_CUSTOM = (#const SDL_LOG_CATEGORY_CUSTOM)
 
+pattern SDL_MESSAGEBOX_ERROR :: forall a. (Num a, Eq a) => a
 pattern SDL_MESSAGEBOX_ERROR = (#const SDL_MESSAGEBOX_ERROR)
+pattern SDL_MESSAGEBOX_WARNING :: forall a. (Num a, Eq a) => a
 pattern SDL_MESSAGEBOX_WARNING = (#const SDL_MESSAGEBOX_WARNING)
+pattern SDL_MESSAGEBOX_INFORMATION :: forall a. (Num a, Eq a) => a
 pattern SDL_MESSAGEBOX_INFORMATION = (#const SDL_MESSAGEBOX_INFORMATION)
 
+pattern SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT :: forall a. (Num a, Eq a) => a
 pattern SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT = (#const SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT)
+pattern SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT :: forall a. (Num a, Eq a) => a
 pattern SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT = (#const SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT)
 
+pattern SDL_GL_CONTEXT_PROFILE_CORE :: forall a. (Num a, Eq a) => a
 pattern SDL_GL_CONTEXT_PROFILE_CORE = (#const SDL_GL_CONTEXT_PROFILE_CORE)
+pattern SDL_GL_CONTEXT_PROFILE_COMPATIBILITY :: forall a. (Num a, Eq a) => a
 pattern SDL_GL_CONTEXT_PROFILE_COMPATIBILITY = (#const SDL_GL_CONTEXT_PROFILE_COMPATIBILITY)
+pattern SDL_GL_CONTEXT_PROFILE_ES :: forall a. (Num a, Eq a) => a
 pattern SDL_GL_CONTEXT_PROFILE_ES = (#const SDL_GL_CONTEXT_PROFILE_ES)
 
+pattern SDL_GL_CONTEXT_DEBUG_FLAG :: forall a. (Num a, Eq a) => a
 pattern SDL_GL_CONTEXT_DEBUG_FLAG = (#const SDL_GL_CONTEXT_DEBUG_FLAG)
+pattern SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG :: forall a. (Num a, Eq a) => a
 pattern SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG = (#const SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG)
+pattern SDL_GL_CONTEXT_ROBUST_ACCESS_FLAG :: forall a. (Num a, Eq a) => a
 pattern SDL_GL_CONTEXT_ROBUST_ACCESS_FLAG = (#const SDL_GL_CONTEXT_ROBUST_ACCESS_FLAG)
+pattern SDL_GL_CONTEXT_RESET_ISOLATION_FLAG :: forall a. (Num a, Eq a) => a
 pattern SDL_GL_CONTEXT_RESET_ISOLATION_FLAG = (#const SDL_GL_CONTEXT_RESET_ISOLATION_FLAG)
 
+pattern SDL_PIXELFORMAT_UNKNOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_UNKNOWN = (#const SDL_PIXELFORMAT_UNKNOWN)
+pattern SDL_PIXELFORMAT_INDEX1LSB :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_INDEX1LSB = (#const SDL_PIXELFORMAT_INDEX1LSB)
+pattern SDL_PIXELFORMAT_INDEX1MSB :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_INDEX1MSB = (#const SDL_PIXELFORMAT_INDEX1MSB)
+pattern SDL_PIXELFORMAT_INDEX4LSB :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_INDEX4LSB = (#const SDL_PIXELFORMAT_INDEX4LSB)
+pattern SDL_PIXELFORMAT_INDEX4MSB :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_INDEX4MSB = (#const SDL_PIXELFORMAT_INDEX4MSB)
+pattern SDL_PIXELFORMAT_INDEX8 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_INDEX8 = (#const SDL_PIXELFORMAT_INDEX8)
+pattern SDL_PIXELFORMAT_RGB332 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGB332 = (#const SDL_PIXELFORMAT_RGB332)
+pattern SDL_PIXELFORMAT_RGB444 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGB444 = (#const SDL_PIXELFORMAT_RGB444)
+pattern SDL_PIXELFORMAT_RGB555 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGB555 = (#const SDL_PIXELFORMAT_RGB555)
+pattern SDL_PIXELFORMAT_BGR555 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_BGR555 = (#const SDL_PIXELFORMAT_BGR555)
+pattern SDL_PIXELFORMAT_ARGB4444 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_ARGB4444 = (#const SDL_PIXELFORMAT_ARGB4444)
+pattern SDL_PIXELFORMAT_RGBA4444 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGBA4444 = (#const SDL_PIXELFORMAT_RGBA4444)
+pattern SDL_PIXELFORMAT_ABGR4444 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_ABGR4444 = (#const SDL_PIXELFORMAT_ABGR4444)
+pattern SDL_PIXELFORMAT_BGRA4444 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_BGRA4444 = (#const SDL_PIXELFORMAT_BGRA4444)
+pattern SDL_PIXELFORMAT_ARGB1555 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_ARGB1555 = (#const SDL_PIXELFORMAT_ARGB1555)
+pattern SDL_PIXELFORMAT_RGBA5551 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGBA5551 = (#const SDL_PIXELFORMAT_RGBA5551)
+pattern SDL_PIXELFORMAT_ABGR1555 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_ABGR1555 = (#const SDL_PIXELFORMAT_ABGR1555)
+pattern SDL_PIXELFORMAT_BGRA5551 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_BGRA5551 = (#const SDL_PIXELFORMAT_BGRA5551)
+pattern SDL_PIXELFORMAT_RGB565 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGB565 = (#const SDL_PIXELFORMAT_RGB565)
+pattern SDL_PIXELFORMAT_BGR565 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_BGR565 = (#const SDL_PIXELFORMAT_BGR565)
+pattern SDL_PIXELFORMAT_RGB24 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGB24 = (#const SDL_PIXELFORMAT_RGB24)
+pattern SDL_PIXELFORMAT_BGR24 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_BGR24 = (#const SDL_PIXELFORMAT_BGR24)
+pattern SDL_PIXELFORMAT_RGB888 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGB888 = (#const SDL_PIXELFORMAT_RGB888)
+pattern SDL_PIXELFORMAT_RGBX8888 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGBX8888 = (#const SDL_PIXELFORMAT_RGBX8888)
+pattern SDL_PIXELFORMAT_BGR888 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_BGR888 = (#const SDL_PIXELFORMAT_BGR888)
+pattern SDL_PIXELFORMAT_BGRX8888 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_BGRX8888 = (#const SDL_PIXELFORMAT_BGRX8888)
+pattern SDL_PIXELFORMAT_ARGB8888 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_ARGB8888 = (#const SDL_PIXELFORMAT_ARGB8888)
+pattern SDL_PIXELFORMAT_RGBA8888 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_RGBA8888 = (#const SDL_PIXELFORMAT_RGBA8888)
+pattern SDL_PIXELFORMAT_ABGR8888 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_ABGR8888 = (#const SDL_PIXELFORMAT_ABGR8888)
+pattern SDL_PIXELFORMAT_BGRA8888 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_BGRA8888 = (#const SDL_PIXELFORMAT_BGRA8888)
+pattern SDL_PIXELFORMAT_ARGB2101010 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_ARGB2101010 = (#const SDL_PIXELFORMAT_ARGB2101010)
+pattern SDL_PIXELFORMAT_YV12 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_YV12 = (#const SDL_PIXELFORMAT_YV12)
+pattern SDL_PIXELFORMAT_IYUV :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_IYUV = (#const SDL_PIXELFORMAT_IYUV)
+pattern SDL_PIXELFORMAT_YUY2 :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_YUY2 = (#const SDL_PIXELFORMAT_YUY2)
+pattern SDL_PIXELFORMAT_UYVY :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_UYVY = (#const SDL_PIXELFORMAT_UYVY)
+pattern SDL_PIXELFORMAT_YVYU :: forall a. (Num a, Eq a) => a
 pattern SDL_PIXELFORMAT_YVYU = (#const SDL_PIXELFORMAT_YVYU)
 
+pattern SDL_RENDERER_SOFTWARE :: forall a. (Num a, Eq a) => a
 pattern SDL_RENDERER_SOFTWARE = (#const SDL_RENDERER_SOFTWARE)
+pattern SDL_RENDERER_ACCELERATED :: forall a. (Num a, Eq a) => a
 pattern SDL_RENDERER_ACCELERATED = (#const SDL_RENDERER_ACCELERATED)
+pattern SDL_RENDERER_PRESENTVSYNC :: forall a. (Num a, Eq a) => a
 pattern SDL_RENDERER_PRESENTVSYNC = (#const SDL_RENDERER_PRESENTVSYNC)
+pattern SDL_RENDERER_TARGETTEXTURE :: forall a. (Num a, Eq a) => a
 pattern SDL_RENDERER_TARGETTEXTURE = (#const SDL_RENDERER_TARGETTEXTURE)
 
+pattern SDL_TEXTUREACCESS_STATIC :: forall a. (Num a, Eq a) => a
 pattern SDL_TEXTUREACCESS_STATIC = (#const SDL_TEXTUREACCESS_STATIC)
+pattern SDL_TEXTUREACCESS_STREAMING :: forall a. (Num a, Eq a) => a
 pattern SDL_TEXTUREACCESS_STREAMING = (#const SDL_TEXTUREACCESS_STREAMING)
+pattern SDL_TEXTUREACCESS_TARGET :: forall a. (Num a, Eq a) => a
 pattern SDL_TEXTUREACCESS_TARGET = (#const SDL_TEXTUREACCESS_TARGET)
 
+pattern SDL_TEXTUREMODULATE_NONE :: forall a. (Num a, Eq a) => a
 pattern SDL_TEXTUREMODULATE_NONE = (#const SDL_TEXTUREMODULATE_NONE)
+pattern SDL_TEXTUREMODULATE_COLOR :: forall a. (Num a, Eq a) => a
 pattern SDL_TEXTUREMODULATE_COLOR = (#const SDL_TEXTUREMODULATE_COLOR)
+pattern SDL_TEXTUREMODULATE_ALPHA :: forall a. (Num a, Eq a) => a
 pattern SDL_TEXTUREMODULATE_ALPHA = (#const SDL_TEXTUREMODULATE_ALPHA)
 
+pattern SDL_TOUCH_MOUSEID :: forall a. (Num a, Eq a) => a
 pattern SDL_TOUCH_MOUSEID = (#const SDL_TOUCH_MOUSEID)
 
+pattern SDL_WINDOWEVENT_NONE :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_NONE = (#const SDL_WINDOWEVENT_NONE)
+pattern SDL_WINDOWEVENT_SHOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_SHOWN = (#const SDL_WINDOWEVENT_SHOWN)
+pattern SDL_WINDOWEVENT_HIDDEN :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_HIDDEN = (#const SDL_WINDOWEVENT_HIDDEN)
+pattern SDL_WINDOWEVENT_EXPOSED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_EXPOSED = (#const SDL_WINDOWEVENT_EXPOSED)
+pattern SDL_WINDOWEVENT_MOVED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_MOVED = (#const SDL_WINDOWEVENT_MOVED)
+pattern SDL_WINDOWEVENT_RESIZED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_RESIZED = (#const SDL_WINDOWEVENT_RESIZED)
+pattern SDL_WINDOWEVENT_SIZE_CHANGED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_SIZE_CHANGED = (#const SDL_WINDOWEVENT_SIZE_CHANGED)
+pattern SDL_WINDOWEVENT_MINIMIZED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_MINIMIZED = (#const SDL_WINDOWEVENT_MINIMIZED)
+pattern SDL_WINDOWEVENT_MAXIMIZED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_MAXIMIZED = (#const SDL_WINDOWEVENT_MAXIMIZED)
+pattern SDL_WINDOWEVENT_RESTORED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_RESTORED = (#const SDL_WINDOWEVENT_RESTORED)
+pattern SDL_WINDOWEVENT_ENTER :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_ENTER = (#const SDL_WINDOWEVENT_ENTER)
+pattern SDL_WINDOWEVENT_LEAVE :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_LEAVE = (#const SDL_WINDOWEVENT_LEAVE)
+pattern SDL_WINDOWEVENT_FOCUS_GAINED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_FOCUS_GAINED = (#const SDL_WINDOWEVENT_FOCUS_GAINED)
+pattern SDL_WINDOWEVENT_FOCUS_LOST :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_FOCUS_LOST = (#const SDL_WINDOWEVENT_FOCUS_LOST)
+pattern SDL_WINDOWEVENT_CLOSE :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWEVENT_CLOSE = (#const SDL_WINDOWEVENT_CLOSE)
 
+pattern SDL_WINDOW_FULLSCREEN :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_FULLSCREEN = (#const SDL_WINDOW_FULLSCREEN)
+pattern SDL_WINDOW_OPENGL :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_OPENGL = (#const SDL_WINDOW_OPENGL)
+pattern SDL_WINDOW_SHOWN :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_SHOWN = (#const SDL_WINDOW_SHOWN)
+pattern SDL_WINDOW_HIDDEN :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_HIDDEN = (#const SDL_WINDOW_HIDDEN)
+pattern SDL_WINDOW_BORDERLESS :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_BORDERLESS = (#const SDL_WINDOW_BORDERLESS)
+pattern SDL_WINDOW_RESIZABLE :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_RESIZABLE = (#const SDL_WINDOW_RESIZABLE)
+pattern SDL_WINDOW_MINIMIZED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_MINIMIZED = (#const SDL_WINDOW_MINIMIZED)
+pattern SDL_WINDOW_MAXIMIZED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_MAXIMIZED = (#const SDL_WINDOW_MAXIMIZED)
+pattern SDL_WINDOW_INPUT_GRABBED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_INPUT_GRABBED = (#const SDL_WINDOW_INPUT_GRABBED)
+pattern SDL_WINDOW_INPUT_FOCUS :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_INPUT_FOCUS = (#const SDL_WINDOW_INPUT_FOCUS)
+pattern SDL_WINDOW_MOUSE_FOCUS :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_MOUSE_FOCUS = (#const SDL_WINDOW_MOUSE_FOCUS)
+pattern SDL_WINDOW_FULLSCREEN_DESKTOP :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_FULLSCREEN_DESKTOP = (#const SDL_WINDOW_FULLSCREEN_DESKTOP)
+pattern SDL_WINDOW_FOREIGN :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_FOREIGN = (#const SDL_WINDOW_FOREIGN)
+pattern SDL_WINDOW_ALLOW_HIGHDPI :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOW_ALLOW_HIGHDPI = (#const SDL_WINDOW_ALLOW_HIGHDPI)
 
+pattern SDL_WINDOWPOS_UNDEFINED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWPOS_UNDEFINED = (#const SDL_WINDOWPOS_UNDEFINED)
+pattern SDL_WINDOWPOS_CENTERED :: forall a. (Num a, Eq a) => a
 pattern SDL_WINDOWPOS_CENTERED = (#const SDL_WINDOWPOS_CENTERED)
 
+pattern SDL_HAPTIC_CONSTANT :: forall a. (Num a, Eq a) => a
 pattern SDL_HAPTIC_CONSTANT = (#const SDL_HAPTIC_CONSTANT)

--- a/src/SDL/Video/OpenGL.hs
+++ b/src/SDL/Video/OpenGL.hs
@@ -97,7 +97,7 @@ newtype GLContext = GLContext Raw.GLContext
 -- support, or if context creation fails.
 --
 -- See @<https://wiki.libsdl.org/SDL_GL_CreateContext SDL_GL_CreateContext>@ for C documentation.
-glCreateContext :: (Functor m, MonadIO m) => Window -> m GLContext
+glCreateContext :: (MonadIO m) => Window -> m GLContext
 glCreateContext (Window w) =
   GLContext <$> throwIfNull "SDL.Video.glCreateContext" "SDL_GL_CreateContext"
     (Raw.glCreateContext w)
@@ -107,7 +107,7 @@ glCreateContext (Window w) =
 -- Throws 'SDLException' on failure.
 --
 -- See @<https://wiki.libsdl.org/SDL_GL_MakeCurrent SDL_GL_MakeCurrent>@ for C documentation.
-glMakeCurrent :: (Functor m, MonadIO m) => Window -> GLContext -> m ()
+glMakeCurrent :: (MonadIO m) => Window -> GLContext -> m ()
 glMakeCurrent (Window w) (GLContext ctx) =
   throwIfNeg_ "SDL.Video.OpenGL.glMakeCurrent" "SDL_GL_MakeCurrent" $
     Raw.glMakeCurrent w ctx

--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -164,7 +164,7 @@ surfaceBlit (Surface src _) srcRect (Surface dst _) dstLoc = liftIO $
 -- | Create a texture for a rendering context.
 --
 -- See @<https://wiki.libsdl.org/SDL_CreateTexture SDL_CreateTexture>@ for C documentation.
-createTexture :: (Functor m,MonadIO m)
+createTexture :: MonadIO m
               => Renderer -- ^ The rendering context.
               -> PixelFormat
               -> TextureAccess
@@ -178,7 +178,7 @@ createTexture (Renderer r) fmt access (V2 w h) =
 -- | Create a texture from an existing surface.
 --
 -- See @<https://wiki.libsdl.org/SDL_CreateTextureFromSurface SDL_CreateTextureFromSurface>@ for C documentation.
-createTextureFromSurface :: (Functor m,MonadIO m)
+createTextureFromSurface :: MonadIO m
                          => Renderer -- ^ The rendering context
                          -> Surface -- ^ The surface containing pixel data used to fill the texture
                          -> m Texture
@@ -190,7 +190,7 @@ createTextureFromSurface (Renderer r) (Surface s _) =
 -- | Bind an OpenGL\/ES\/ES2 texture to the current context for use with when rendering OpenGL primitives directly.
 --
 -- See @<https://wiki.libsdl.org/SDL_GL_BindTexture SDL_GL_BindTexture>@ for C documentation.
-glBindTexture :: (Functor m,MonadIO m)
+glBindTexture :: MonadIO m
               => Texture -- ^ The texture to bind to the current OpenGL\/ES\/ES2 context
               -> m ()
 glBindTexture (Texture t) =
@@ -200,7 +200,7 @@ glBindTexture (Texture t) =
 -- | Unbind an OpenGL\/ES\/ES2 texture from the current context.
 --
 -- See @<https://wiki.libsdl.org/SDL_GL_UnbindTexture SDL_GL_UnbindTexture>@ for C documentation.
-glUnbindTexture :: (Functor m,MonadIO m)
+glUnbindTexture :: MonadIO m
                 => Texture -- ^ The texture to unbind from the current OpenGL\/ES\/ES2 context
                 -> m ()
 glUnbindTexture (Texture t) =
@@ -306,7 +306,7 @@ queryTexture (Texture tex) = liftIO $
 -- | Allocate a new RGB surface.
 --
 -- See @<https://wiki.libsdl.org/SDL_CreateRGBSurface SDL_CreateRGBSurface>@ for C documentation.
-createRGBSurface :: (Functor m, MonadIO m)
+createRGBSurface :: MonadIO m
                  => V2 CInt -- ^ The size of the surface
                  -> PixelFormat -- ^ The bit depth, red, green, blue and alpha mask for the pixels
                  -> m Surface
@@ -319,7 +319,7 @@ createRGBSurface (V2 w h) pf =
 -- | Allocate a new RGB surface with existing pixel data.
 --
 -- See @<https://wiki.libsdl.org/SDL_CreateRGBSurfaceFrom SDL_CreateRGBSurfaceFrom>@ for C documentation.
-createRGBSurfaceFrom :: (Functor m, MonadIO m)
+createRGBSurfaceFrom :: MonadIO m
                      => MSV.IOVector Word8 -- ^ The existing pixel data
                      -> V2 CInt -- ^ The size of the surface
                      -> CInt -- ^ The pitch - the length of a row of pixels in bytes
@@ -454,7 +454,7 @@ setPaletteColors (Palette p) colors first = liftIO $
 -- | Get the SDL surface associated with the window.
 --
 -- See @<https://wiki.libsdl.org/SDL_GetWindowSurface SDL_GetWindowSurface>@ for C documentation.
-getWindowSurface :: (Functor m, MonadIO m) => Window -> m Surface
+getWindowSurface :: MonadIO m => Window -> m Surface
 getWindowSurface (Window w) =
   fmap unmanagedSurface $
   throwIfNull "SDL.Video.getWindowSurface" "SDL_GetWindowSurface" $
@@ -504,7 +504,7 @@ rendererDrawColor (Renderer re) = makeStateVar getRenderDrawColor setRenderDrawC
 -- This is the function you use to reflect any changes to the surface on the screen.
 --
 -- See @<https://wiki.libsdl.org/SDL_UpdateWindowSurface SDL_UpdateWindowSurface>@ for C documentation.
-updateWindowSurface :: (Functor m, MonadIO m) => Window -> m ()
+updateWindowSurface :: MonadIO m => Window -> m ()
 updateWindowSurface (Window w) =
   throwIfNeg_ "SDL.Video.updateWindowSurface" "SDL_UpdateWindowSurface" $
     Raw.updateWindowSurface w
@@ -625,7 +625,7 @@ fillRects (Renderer r) rects = liftIO $
 -- | Clear the current rendering target with the drawing color.
 --
 -- See @<https://wiki.libsdl.org/SDL_RenderClear SDL_RenderClear>@ for C documentation.
-clear :: (Functor m, MonadIO m) => Renderer -> m ()
+clear :: MonadIO m => Renderer -> m ()
 clear (Renderer r) =
   throwIfNeg_ "SDL.Video.clear" "SDL_RenderClear" $
   Raw.renderClear r
@@ -739,7 +739,7 @@ copyEx (Renderer r) (Texture t) srcRect dstRect theta center flips =
 -- | Draw a line on the current rendering target.
 --
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawLine SDL_RenderDrawLine>@ for C documentation.
-drawLine :: (Functor m,MonadIO m)
+drawLine :: MonadIO m
          => Renderer
          -> Point V2 CInt -- ^ The start point of the line
          -> Point V2 CInt -- ^ The end point of the line
@@ -766,7 +766,7 @@ drawLines (Renderer r) points =
 -- | Draw a point on the current rendering target.
 --
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawPoint SDL_RenderDrawPoint>@ for C documentation.
-drawPoint :: (Functor m, MonadIO m) => Renderer -> Point V2 CInt -> m ()
+drawPoint :: MonadIO m => Renderer -> Point V2 CInt -> m ()
 drawPoint (Renderer r) (P (V2 x y)) =
   throwIfNeg_ "SDL.Video.drawPoint" "SDL_RenderDrawPoint" $
   Raw.renderDrawPoint r x y
@@ -788,7 +788,7 @@ drawPoints (Renderer r) points =
 -- This function is used to optimize images for faster repeat blitting. This is accomplished by converting the original and storing the result as a new surface. The new, optimized surface can then be used as the source for future blits, making them faster.
 --
 -- See @<https://wiki.libsdl.org/SDL_ConvertSurface SDL_ConvertSurface>@ for C documentation.
-convertSurface :: (Functor m,MonadIO m)
+convertSurface :: MonadIO m
                => Surface -- ^ The 'Surface' to convert
                -> SurfacePixelFormat -- ^ The pixel format that the new surface is optimized for
                -> m Surface


### PR DESCRIPTION
This covers:
- Missing top-level type definitions
- Redundant type constraints

It's really refreshing to be able to compile sdl2 without the extra noise.