### PR TITLE
Make 'linear' package dependency optional

### DIFF
--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -44,6 +44,11 @@ flag examples
   description:       Build examples
   default:           False
 
+flag nolinear
+  description:       Do not depend on 'linear' library
+  default:           False
+  manual:            True
+
 library
   ghc-options: -Wall
 
@@ -86,6 +91,7 @@ library
   other-modules:
     Data.Bitmask
     SDL.Internal.Numbered
+    SDL.Internal.Vect
     SDL.Exception
 
   hs-source-dirs:
@@ -115,6 +121,12 @@ library
     text >= 1.1.0.0 && < 1.3,
     transformers >= 0.2 && < 0.6,
     vector >= 0.10.9.0 && < 0.12
+
+  if flag(nolinear)
+    cpp-options: -Dnolinear
+  else
+    build-depends:
+      linear >= 1.10.1.2 && < 1.21
 
   default-language:
     Haskell2010

--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -72,6 +72,7 @@ library
     SDL.Video.Renderer
 
     SDL.Internal.Types
+    SDL.Internal.Vect
 
     SDL.Raw
     SDL.Raw.Audio
@@ -91,7 +92,6 @@ library
   other-modules:
     Data.Bitmask
     SDL.Internal.Numbered
-    SDL.Internal.Vect
     SDL.Exception
 
   hs-source-dirs:

--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -61,6 +61,7 @@ library
     SDL.Input.Mouse
     SDL.Power
     SDL.Time
+    SDL.Vect
     SDL.Video
     SDL.Video.OpenGL
     SDL.Video.Renderer
@@ -110,7 +111,6 @@ library
     base >= 4.7 && < 5,
     bytestring >= 0.10.4.0 && < 0.11,
     exceptions >= 0.4 && < 0.9,
-    linear >= 1.10.1.2 && < 1.21,
     StateVar >= 1.1.0.0 && < 1.2,
     text >= 1.1.0.0 && < 1.3,
     transformers >= 0.2 && < 0.6,
@@ -388,7 +388,7 @@ executable twinklebear-lesson-05
 
 executable audio-example
   if flag(examples)
-    build-depends: base >= 4.7 && < 5, lens >= 4.4.0.2 && < 4.15, linear >= 1.10.1.2 && < 1.21, sdl2, vector
+    build-depends: base >= 4.7 && < 5, sdl2, vector
   else
     buildable: False
 

--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -44,7 +44,7 @@ flag examples
   description:       Build examples
   default:           False
 
-flag nolinear
+flag no-linear
   description:       Do not depend on 'linear' library
   default:           False
   manual:            True
@@ -122,7 +122,7 @@ library
     transformers >= 0.2 && < 0.6,
     vector >= 0.10.9.0 && < 0.12
 
-  if flag(nolinear)
+  if flag(no-linear)
     cpp-options: -Dnolinear
   else
     build-depends:

--- a/src/SDL.hs
+++ b/src/SDL.hs
@@ -23,6 +23,7 @@ module SDL
   , module SDL.Input
   , module SDL.Power
   , module SDL.Time
+  , module SDL.Vect
   , module SDL.Video
 
   -- * Working with State Variables
@@ -45,6 +46,7 @@ import SDL.Init
 import SDL.Input
 import SDL.Power
 import SDL.Time
+import SDL.Vect
 import SDL.Video
 
 {- $gettingStarted

--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -169,7 +169,7 @@ data WindowExposedEventData =
 data WindowMovedEventData =
   WindowMovedEventData {windowMovedEventWindow :: Window
                         -- ^ The associated 'Window'.
-                       ,windowMovedEventPosition :: V2 Int32
+                       ,windowMovedEventPosition :: Point V2 Int32
                         -- ^ The new position of the 'Window'.
                        }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -289,7 +289,7 @@ data MouseMotionEventData =
                         -- ^ The 'MouseDevice' that was moved.
                        ,mouseMotionEventState :: [MouseButton]
                         -- ^ A collection of 'MouseButton's that are currently held down.
-                       ,mouseMotionEventPos :: V2 Int32
+                       ,mouseMotionEventPos :: Point V2 Int32
                         -- ^ The new position of the mouse.
                        ,mouseMotionEventRelMotion :: V2 Int32
                         -- ^ The relative mouse motion of the mouse.
@@ -308,7 +308,7 @@ data MouseButtonEventData =
                         -- ^ The button that was pressed or released.
                        ,mouseButtonEventClicks :: Word8
                         -- ^ The amount of clicks. 1 for a single-click, 2 for a double-click, etc.
-                       ,mouseButtonEventPos :: V2 Int32
+                       ,mouseButtonEventPos :: Point V2 Int32
                         -- ^ The coordinates of the mouse click.
                        }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -428,7 +428,7 @@ data TouchFingerEventData =
                         -- ^ The touch device index.
                        ,touchFingerEventFingerID :: Raw.FingerID
                         -- ^ The finger index.
-                       ,touchFingerEventPos :: V2 CFloat
+                       ,touchFingerEventPos :: Point V2 CFloat
                         -- ^ The location of the touch event, normalized between 0 and 1.
                        ,touchFingerEventRelMotion :: V2 CFloat
                         -- ^ The distance moved, normalized between -1 and 1.
@@ -445,7 +445,7 @@ data MultiGestureEventData =
                          -- ^ The amount that the fingers rotated during this motion.
                         ,multiGestureEventDDist :: CFloat
                          -- ^ The amount that the fingers pinched during this motion.
-                        ,multiGestureEventPos :: V2 CFloat
+                        ,multiGestureEventPos :: Point V2 CFloat
                          -- ^ The normalized center of the gesture.
                         ,multiGestureEventNumFingers :: Word16
                          -- ^ The number of fingers used in this gesture.
@@ -462,7 +462,7 @@ data DollarGestureEventData =
                           -- ^ The number of fingers used to draw the stroke.
                          ,dollarGestureEventError :: CFloat
                           -- ^ The difference between the gesture template and the actual performed gesture (lower errors correspond to closer matches).
-                         ,dollarGestureEventPos :: V2 CFloat
+                         ,dollarGestureEventPos :: Point V2 CFloat
                           -- ^ The normalized center of the gesture.
                          }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -513,7 +513,7 @@ convertRaw (Raw.WindowEvent t ts a b c d) =
                       Raw.SDL_WINDOWEVENT_MOVED ->
                         WindowMovedEvent
                           (WindowMovedEventData w'
-                                                ((V2 c d)))
+                                                (P (V2 c d)))
                       Raw.SDL_WINDOWEVENT_RESIZED ->
                         WindowResizedEvent
                           (WindowResizedEventData w'
@@ -582,7 +582,7 @@ convertRaw (Raw.MouseMotionEvent _ ts a b c d e f g) =
                       (MouseMotionEventData w'
                                             (fromNumber b)
                                             buttons
-                                            ((V2 d e))
+                                            (P (V2 d e))
                                             (V2 f g))))
   where mask `test` x =
           if mask .&. x /= 0
@@ -608,7 +608,7 @@ convertRaw (Raw.MouseButtonEvent t ts a b c _ e f g) =
                                             (fromNumber b)
                                             button
                                             e
-                                            ((V2 f g)))))
+                                            (P (V2 f g)))))
 convertRaw (Raw.MouseWheelEvent _ ts a b c d) =
   do w' <- fmap Window (Raw.getWindowFromID a)
      return (Event ts
@@ -648,7 +648,7 @@ convertRaw (Raw.TouchFingerEvent _ ts a b c d e f g) =
                 (TouchFingerEvent
                    (TouchFingerEventData a
                                          b
-                                         ((V2 c d))
+                                         (P (V2 c d))
                                          (V2 e f)
                                          g)))
 convertRaw (Raw.MultiGestureEvent _ ts a b c d e f) =
@@ -657,7 +657,7 @@ convertRaw (Raw.MultiGestureEvent _ ts a b c d e f) =
                    (MultiGestureEventData a
                                           b
                                           c
-                                          ((V2 d e))
+                                          (P (V2 d e))
                                           f)))
 convertRaw (Raw.DollarGestureEvent _ ts a b c d e f) =
   return (Event ts
@@ -666,7 +666,7 @@ convertRaw (Raw.DollarGestureEvent _ ts a b c d e f) =
                                            b
                                            c
                                            d
-                                           ((V2 e f)))))
+                                           (P (V2 e f)))))
 convertRaw (Raw.DropEvent _ ts a) =
   return (Event ts (DropEvent (DropEventData a)))
 convertRaw (Raw.ClipboardUpdateEvent _ ts) =

--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -80,8 +80,7 @@ import Data.Typeable
 import Foreign
 import Foreign.C
 import GHC.Generics (Generic)
-import Linear
-import Linear.Affine (Point(P))
+import SDL.Vect
 import SDL.Input.Keyboard
 import SDL.Input.Mouse
 import SDL.Internal.Numbered
@@ -170,7 +169,7 @@ data WindowExposedEventData =
 data WindowMovedEventData =
   WindowMovedEventData {windowMovedEventWindow :: Window
                         -- ^ The associated 'Window'.
-                       ,windowMovedEventPosition :: Point V2 Int32
+                       ,windowMovedEventPosition :: V2 Int32
                         -- ^ The new position of the 'Window'.
                        }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -290,7 +289,7 @@ data MouseMotionEventData =
                         -- ^ The 'MouseDevice' that was moved.
                        ,mouseMotionEventState :: [MouseButton]
                         -- ^ A collection of 'MouseButton's that are currently held down.
-                       ,mouseMotionEventPos :: Point V2 Int32
+                       ,mouseMotionEventPos :: V2 Int32
                         -- ^ The new position of the mouse.
                        ,mouseMotionEventRelMotion :: V2 Int32
                         -- ^ The relative mouse motion of the mouse.
@@ -309,7 +308,7 @@ data MouseButtonEventData =
                         -- ^ The button that was pressed or released.
                        ,mouseButtonEventClicks :: Word8
                         -- ^ The amount of clicks. 1 for a single-click, 2 for a double-click, etc.
-                       ,mouseButtonEventPos :: Point V2 Int32
+                       ,mouseButtonEventPos :: V2 Int32
                         -- ^ The coordinates of the mouse click.
                        }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -429,7 +428,7 @@ data TouchFingerEventData =
                         -- ^ The touch device index.
                        ,touchFingerEventFingerID :: Raw.FingerID
                         -- ^ The finger index.
-                       ,touchFingerEventPos :: Point V2 CFloat
+                       ,touchFingerEventPos :: V2 CFloat
                         -- ^ The location of the touch event, normalized between 0 and 1.
                        ,touchFingerEventRelMotion :: V2 CFloat
                         -- ^ The distance moved, normalized between -1 and 1.
@@ -446,7 +445,7 @@ data MultiGestureEventData =
                          -- ^ The amount that the fingers rotated during this motion.
                         ,multiGestureEventDDist :: CFloat
                          -- ^ The amount that the fingers pinched during this motion.
-                        ,multiGestureEventPos :: Point V2 CFloat
+                        ,multiGestureEventPos :: V2 CFloat
                          -- ^ The normalized center of the gesture.
                         ,multiGestureEventNumFingers :: Word16
                          -- ^ The number of fingers used in this gesture.
@@ -463,7 +462,7 @@ data DollarGestureEventData =
                           -- ^ The number of fingers used to draw the stroke.
                          ,dollarGestureEventError :: CFloat
                           -- ^ The difference between the gesture template and the actual performed gesture (lower errors correspond to closer matches).
-                         ,dollarGestureEventPos :: Point V2 CFloat
+                         ,dollarGestureEventPos :: V2 CFloat
                           -- ^ The normalized center of the gesture.
                          }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -514,7 +513,7 @@ convertRaw (Raw.WindowEvent t ts a b c d) =
                       Raw.SDL_WINDOWEVENT_MOVED ->
                         WindowMovedEvent
                           (WindowMovedEventData w'
-                                                (P (V2 c d)))
+                                                ((V2 c d)))
                       Raw.SDL_WINDOWEVENT_RESIZED ->
                         WindowResizedEvent
                           (WindowResizedEventData w'
@@ -583,7 +582,7 @@ convertRaw (Raw.MouseMotionEvent _ ts a b c d e f g) =
                       (MouseMotionEventData w'
                                             (fromNumber b)
                                             buttons
-                                            (P (V2 d e))
+                                            ((V2 d e))
                                             (V2 f g))))
   where mask `test` x =
           if mask .&. x /= 0
@@ -609,7 +608,7 @@ convertRaw (Raw.MouseButtonEvent t ts a b c _ e f g) =
                                             (fromNumber b)
                                             button
                                             e
-                                            (P (V2 f g)))))
+                                            ((V2 f g)))))
 convertRaw (Raw.MouseWheelEvent _ ts a b c d) =
   do w' <- fmap Window (Raw.getWindowFromID a)
      return (Event ts
@@ -649,7 +648,7 @@ convertRaw (Raw.TouchFingerEvent _ ts a b c d e f g) =
                 (TouchFingerEvent
                    (TouchFingerEventData a
                                          b
-                                         (P (V2 c d))
+                                         ((V2 c d))
                                          (V2 e f)
                                          g)))
 convertRaw (Raw.MultiGestureEvent _ ts a b c d e f) =
@@ -658,7 +657,7 @@ convertRaw (Raw.MultiGestureEvent _ ts a b c d e f) =
                    (MultiGestureEventData a
                                           b
                                           c
-                                          (P (V2 d e))
+                                          ((V2 d e))
                                           f)))
 convertRaw (Raw.DollarGestureEvent _ ts a b c d e f) =
   return (Event ts
@@ -667,7 +666,7 @@ convertRaw (Raw.DollarGestureEvent _ ts a b c d e f) =
                                            b
                                            c
                                            d
-                                           (P (V2 e f)))))
+                                           ((V2 e f)))))
 convertRaw (Raw.DropEvent _ ts a) =
   return (Event ts (DropEvent (DropEventData a)))
 convertRaw (Raw.ClipboardUpdateEvent _ ts) =

--- a/src/SDL/Input/Joystick.hs
+++ b/src/SDL/Input/Joystick.hs
@@ -30,7 +30,7 @@ import Foreign.C.Types
 import Foreign.Marshal.Alloc
 import Foreign.Storable
 import GHC.Generics (Generic)
-import Linear
+import SDL.Vect
 import SDL.Exception
 import SDL.Internal.Types
 import qualified Data.ByteString as BS

--- a/src/SDL/Input/Mouse.hs
+++ b/src/SDL/Input/Mouse.hs
@@ -52,8 +52,7 @@ import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import Foreign.Storable
 import GHC.Generics (Generic)
-import Linear
-import Linear.Affine
+import SDL.Vect
 import SDL.Exception
 import SDL.Internal.Numbered
 import SDL.Internal.Types (Window(Window))
@@ -85,7 +84,7 @@ getMouseLocationMode = do
   return $ if relativeMode then RelativeLocation else AbsoluteLocation
 
 -- | Return proper mouse location depending on mouse mode
-getModalMouseLocation :: MonadIO m => m (LocationMode, Point V2 CInt)
+getModalMouseLocation :: MonadIO m => m (LocationMode, V2 CInt)
 getModalMouseLocation = do
   mode <- getMouseLocationMode
   location <- case mode of
@@ -106,7 +105,7 @@ getRelativeMouseMode :: MonadIO m => m Bool
 getRelativeMouseMode = Raw.getRelativeMouseMode
 
 --deprecated
-getMouseLocation :: MonadIO m => m (Point V2 CInt)
+getMouseLocation :: MonadIO m => m (V2 CInt)
 {-# DEPRECATED getMouseLocation "Use getAbsoluteMouseLocation instead, or getModalMouseLocation to match future behavior." #-}
 getMouseLocation = getAbsoluteMouseLocation
 
@@ -139,9 +138,9 @@ data WarpMouseOrigin
   deriving (Data, Eq, Generic, Ord, Show, Typeable)
 
 -- | Move the current location of a mouse pointer. The 'WarpMouseOrigin' specifies the origin for the given warp coordinates.
-warpMouse :: MonadIO m => WarpMouseOrigin -> Point V2 CInt -> m ()
-warpMouse (WarpInWindow (Window w)) (P (V2 x y)) = Raw.warpMouseInWindow w x y
-warpMouse WarpCurrentFocus (P (V2 x y)) = Raw.warpMouseInWindow nullPtr x y
+warpMouse :: MonadIO m => WarpMouseOrigin -> V2 CInt -> m ()
+warpMouse (WarpInWindow (Window w)) ((V2 x y)) = Raw.warpMouseInWindow w x y
+warpMouse WarpCurrentFocus ((V2 x y)) = Raw.warpMouseInWindow nullPtr x y
 
 -- | Get or set whether the cursor is currently visible.
 --
@@ -160,20 +159,20 @@ cursorVisible = makeStateVar getCursorVisible setCursorVisible
   getCursorVisible = (== 1) <$> Raw.showCursor (-1)
 
 -- | Retrieve the current location of the mouse, relative to the currently focused window.
-getAbsoluteMouseLocation :: MonadIO m => m (Point V2 CInt)
+getAbsoluteMouseLocation :: MonadIO m => m (V2 CInt)
 getAbsoluteMouseLocation = liftIO $
   alloca $ \x ->
   alloca $ \y -> do
     _ <- Raw.getMouseState x y -- We don't deal with button states here
-    P <$> (V2 <$> peek x <*> peek y)
+    (V2 <$> peek x <*> peek y)
 
 -- | Retrieve mouse motion
-getRelativeMouseLocation :: MonadIO m => m (Point V2 CInt)
+getRelativeMouseLocation :: MonadIO m => m (V2 CInt)
 getRelativeMouseLocation = liftIO $
   alloca $ \x ->
   alloca $ \y -> do
     _ <- Raw.getRelativeMouseState x y
-    P <$> (V2 <$> peek x <*> peek y)
+    (V2 <$> peek x <*> peek y)
 
 
 -- | Retrieve a mapping of which buttons are currently held down.
@@ -217,9 +216,9 @@ createCursor :: MonadIO m
              => V.Vector Bool -- ^ Whether this part of the cursor is black. Use 'False' for white and 'True' for black.
              -> V.Vector Bool -- ^ Whether or not pixels are visible. Use 'True' for visible and 'False' for transparent.
              -> V2 CInt -- ^ The width and height of the cursor.
-             -> Point V2 CInt -- ^ The X- and Y-axis location of the upper left corner of the cursor relative to the actual mouse position
+             -> V2 CInt -- ^ The X- and Y-axis location of the upper left corner of the cursor relative to the actual mouse position
              -> m Cursor
-createCursor dta msk (V2 w h) (P (V2 hx hy)) =
+createCursor dta msk (V2 w h) ((V2 hx hy)) =
     liftIO . fmap Cursor $
         throwIfNull "SDL.Input.Mouse.createCursor" "SDL_createCursor" $
             V.unsafeWith (V.map (bool 0 1) dta) $ \unsafeDta ->
@@ -237,9 +236,9 @@ freeCursor = Raw.freeCursor . unwrapCursor
 -- See @<https://wiki.libsdl.org/SDL_CreateColorCursor SDL_CreateColorCursor>@ for C documentation.
 createColorCursor :: MonadIO m
                   => Surface
-                  -> Point V2 CInt -- ^ The location of the cursor hot spot
+                  -> V2 CInt -- ^ The location of the cursor hot spot
                   -> m Cursor
-createColorCursor (Surface surfPtr _) (P (V2 hx hy)) =
+createColorCursor (Surface surfPtr _) ((V2 hx hy)) =
     liftIO . fmap Cursor $
         throwIfNull "SDL.Input.Mouse.createColorCursor" "SDL_createColorCursor" $
             Raw.createColorCursor surfPtr hx hy

--- a/src/SDL/Internal/Vect.hs
+++ b/src/SDL/Internal/Vect.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module SDL.Internal.Vect
+    ( V2(..)
+    , V3(..)
+    , V4(..)
+    ) where
+
+-- Copied from the 'linear' package by Edward Kmett.
+
+import           Control.Applicative (liftA2)
+import           Foreign.Storable
+import           Foreign.Ptr (castPtr)
+
+data V2 a = V2 !a !a
+    deriving (Show, Read, Ord, Eq)
+
+data V3 a = V3 !a !a !a
+    deriving (Show, Read, Ord, Eq)
+
+data V4 a = V4 !a !a !a !a
+    deriving (Show, Read, Ord, Eq)
+
+instance Functor V2 where
+  fmap f (V2 a b) = V2 (f a) (f b)
+  {-# INLINE fmap #-}
+  a <$ _ = V2 a a
+  {-# INLINE (<$) #-}
+
+instance Functor V3 where
+  fmap f (V3 a b c) = V3 (f a) (f b) (f c)
+  {-# INLINE fmap #-}
+  a <$ _ = V3 a a a
+  {-# INLINE (<$) #-}
+
+instance Functor V4 where
+  fmap f (V4 a b c d) = V4 (f a) (f b) (f c) (f d)
+  {-# INLINE fmap #-}
+  a <$ _ = V4 a a a a
+  {-# INLINE (<$) #-}
+
+instance Applicative V2 where
+    pure a = V2 a a
+    V2 a b <*> V2 d e = V2 (a d) (b e)
+
+instance Storable a => Storable (V4 a) where
+  sizeOf _ = 4 * sizeOf (undefined::a)
+  {-# INLINE sizeOf #-}
+  alignment _ = alignment (undefined::a)
+  {-# INLINE alignment #-}
+  poke ptr (V4 x y z w) = do poke ptr' x
+                             pokeElemOff ptr' 1 y
+                             pokeElemOff ptr' 2 z
+                             pokeElemOff ptr' 3 w
+    where ptr' = castPtr ptr
+  {-# INLINE poke #-}
+  peek ptr = V4 <$> peek ptr' <*> peekElemOff ptr' 1
+                <*> peekElemOff ptr' 2 <*> peekElemOff ptr' 3
+    where ptr' = castPtr ptr
+  {-# INLINE peek #-}
+
+instance Storable a => Storable (V2 a) where
+  sizeOf _ = 2 * sizeOf (undefined::a)
+  {-# INLINE sizeOf #-}
+  alignment _ = alignment (undefined::a)
+  {-# INLINE alignment #-}
+  poke ptr (V2 x y) = poke ptr' x >> pokeElemOff ptr' 1 y
+    where ptr' = castPtr ptr
+  {-# INLINE poke #-}
+  peek ptr = V2 <$> peek ptr' <*> peekElemOff ptr' 1
+    where ptr' = castPtr ptr
+  {-# INLINE peek #-}
+
+instance Num a => Num (V2 a) where
+    (+) = liftA2 (+)
+    (-) = liftA2 (-)
+    (*) = liftA2 (*)
+    negate = fmap negate
+    abs = fmap abs
+    signum = fmap signum
+    fromInteger = pure . fromInteger

--- a/src/SDL/Internal/Vect.hs
+++ b/src/SDL/Internal/Vect.hs
@@ -9,7 +9,7 @@ module SDL.Internal.Vect
 
 -- Copied from the 'linear' package by Edward Kmett.
 
-import           Control.Applicative (liftA2)
+import           Control.Applicative (Applicative, liftA2)
 import           Foreign.Storable
 import           Foreign.Ptr (castPtr)
 

--- a/src/SDL/Internal/Vect.hs
+++ b/src/SDL/Internal/Vect.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- 2-D, 3-D and 4-D Vectors.
+-- The interface is compatible with that of the 'linear' package.
 module SDL.Internal.Vect
     ( V2(..)
     , V3(..)
@@ -7,21 +10,38 @@ module SDL.Internal.Vect
     , Point(..)
     ) where
 
--- Copied from the 'linear' package by Edward Kmett.
+-- From the 'linear' package, (c) Edward Kmett.
 
 import           Control.Applicative
 import           Foreign.Storable
 import           Foreign.Ptr (castPtr)
 
+-- | A handy wrapper to help distinguish points from vectors at the
+-- type level.
 newtype Point f a = P (f a)
   deriving (Show, Read, Ord, Eq, Functor, Applicative, Num, Storable)
 
+-- | A 2-dimensional vector
+--
+-- >>> pure 1 :: V2 Int
+-- V2 1 1
+--
+-- >>> V2 1 2 + V2 3 4
+-- V2 4 6
+--
+-- >>> V2 1 2 * V2 3 4
+-- V2 3 8
+--
+-- >>> sum (V2 1 2)
+-- 3
 data V2 a = V2 !a !a
     deriving (Show, Read, Ord, Eq)
 
+-- | A 3-dimensional vector
 data V3 a = V3 !a !a !a
     deriving (Show, Read, Ord, Eq)
 
+-- | A 4-dimensional vector
 data V4 a = V4 !a !a !a !a
     deriving (Show, Read, Ord, Eq)
 

--- a/src/SDL/Internal/Vect.hs
+++ b/src/SDL/Internal/Vect.hs
@@ -9,7 +9,7 @@ module SDL.Internal.Vect
 
 -- Copied from the 'linear' package by Edward Kmett.
 
-import           Control.Applicative (Applicative, liftA2)
+import           Control.Applicative
 import           Foreign.Storable
 import           Foreign.Ptr (castPtr)
 

--- a/src/SDL/Internal/Vect.hs
+++ b/src/SDL/Internal/Vect.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module SDL.Internal.Vect
     ( V2(..)
     , V3(..)
     , V4(..)
+    , Point(..)
     ) where
 
 -- Copied from the 'linear' package by Edward Kmett.
@@ -10,6 +12,9 @@ module SDL.Internal.Vect
 import           Control.Applicative (liftA2)
 import           Foreign.Storable
 import           Foreign.Ptr (castPtr)
+
+newtype Point f a = P (f a)
+  deriving (Show, Read, Ord, Eq, Functor, Applicative, Num, Storable)
 
 data V2 a = V2 !a !a
     deriving (Show, Read, Ord, Eq)

--- a/src/SDL/Vect.hs
+++ b/src/SDL/Vect.hs
@@ -7,6 +7,14 @@
 -- This is useful if one does not want to incur the 'lens' dependency.
 module SDL.Vect
   ( module Vect
+
+  -- * Vectors
+  , V2 (..)
+  , V3 (..)
+  , V4 (..)
+
+  -- * Point
+  , Point (..)
   ) where
 
 #if defined(nolinear)

--- a/src/SDL/Vect.hs
+++ b/src/SDL/Vect.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module SDL.Vect
+    ( V2(..)
+    , V3(..)
+    , V4(..)
+    ) where
+
+-- Copied from the 'linear' package by Edward Kmett.
+
+import           Control.Applicative (liftA2)
+import           Foreign.Storable
+import           Foreign.Ptr (castPtr)
+
+data V2 a = V2 !a !a
+    deriving (Show, Read, Ord, Eq)
+
+data V3 a = V3 !a !a !a
+    deriving (Show, Read, Ord, Eq)
+
+data V4 a = V4 !a !a !a !a
+    deriving (Show, Read, Ord, Eq)
+
+instance Functor V2 where
+  fmap f (V2 a b) = V2 (f a) (f b)
+  {-# INLINE fmap #-}
+  a <$ _ = V2 a a
+  {-# INLINE (<$) #-}
+
+instance Functor V3 where
+  fmap f (V3 a b c) = V3 (f a) (f b) (f c)
+  {-# INLINE fmap #-}
+  a <$ _ = V3 a a a
+  {-# INLINE (<$) #-}
+
+instance Functor V4 where
+  fmap f (V4 a b c d) = V4 (f a) (f b) (f c) (f d)
+  {-# INLINE fmap #-}
+  a <$ _ = V4 a a a a
+  {-# INLINE (<$) #-}
+
+instance Applicative V2 where
+    pure a = V2 a a
+    V2 a b <*> V2 d e = V2 (a d) (b e)
+
+instance Storable a => Storable (V4 a) where
+  sizeOf _ = 4 * sizeOf (undefined::a)
+  {-# INLINE sizeOf #-}
+  alignment _ = alignment (undefined::a)
+  {-# INLINE alignment #-}
+  poke ptr (V4 x y z w) = do poke ptr' x
+                             pokeElemOff ptr' 1 y
+                             pokeElemOff ptr' 2 z
+                             pokeElemOff ptr' 3 w
+    where ptr' = castPtr ptr
+  {-# INLINE poke #-}
+  peek ptr = V4 <$> peek ptr' <*> peekElemOff ptr' 1
+                <*> peekElemOff ptr' 2 <*> peekElemOff ptr' 3
+    where ptr' = castPtr ptr
+  {-# INLINE peek #-}
+
+instance Storable a => Storable (V2 a) where
+  sizeOf _ = 2 * sizeOf (undefined::a)
+  {-# INLINE sizeOf #-}
+  alignment _ = alignment (undefined::a)
+  {-# INLINE alignment #-}
+  poke ptr (V2 x y) = poke ptr' x >> pokeElemOff ptr' 1 y
+    where ptr' = castPtr ptr
+  {-# INLINE poke #-}
+  peek ptr = V2 <$> peek ptr' <*> peekElemOff ptr' 1
+    where ptr' = castPtr ptr
+  {-# INLINE peek #-}
+
+instance Num a => Num (V2 a) where
+    (+) = liftA2 (+)
+    (-) = liftA2 (-)
+    (*) = liftA2 (*)
+    negate = fmap negate
+    abs = fmap abs
+    signum = fmap signum
+    fromInteger = pure . fromInteger

--- a/src/SDL/Vect.hs
+++ b/src/SDL/Vect.hs
@@ -1,80 +1,11 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 module SDL.Vect
-    ( V2(..)
-    , V3(..)
-    , V4(..)
-    ) where
+  ( module Vect
+  ) where
 
--- Copied from the 'linear' package by Edward Kmett.
-
-import           Control.Applicative (liftA2)
-import           Foreign.Storable
-import           Foreign.Ptr (castPtr)
-
-data V2 a = V2 !a !a
-    deriving (Show, Read, Ord, Eq)
-
-data V3 a = V3 !a !a !a
-    deriving (Show, Read, Ord, Eq)
-
-data V4 a = V4 !a !a !a !a
-    deriving (Show, Read, Ord, Eq)
-
-instance Functor V2 where
-  fmap f (V2 a b) = V2 (f a) (f b)
-  {-# INLINE fmap #-}
-  a <$ _ = V2 a a
-  {-# INLINE (<$) #-}
-
-instance Functor V3 where
-  fmap f (V3 a b c) = V3 (f a) (f b) (f c)
-  {-# INLINE fmap #-}
-  a <$ _ = V3 a a a
-  {-# INLINE (<$) #-}
-
-instance Functor V4 where
-  fmap f (V4 a b c d) = V4 (f a) (f b) (f c) (f d)
-  {-# INLINE fmap #-}
-  a <$ _ = V4 a a a a
-  {-# INLINE (<$) #-}
-
-instance Applicative V2 where
-    pure a = V2 a a
-    V2 a b <*> V2 d e = V2 (a d) (b e)
-
-instance Storable a => Storable (V4 a) where
-  sizeOf _ = 4 * sizeOf (undefined::a)
-  {-# INLINE sizeOf #-}
-  alignment _ = alignment (undefined::a)
-  {-# INLINE alignment #-}
-  poke ptr (V4 x y z w) = do poke ptr' x
-                             pokeElemOff ptr' 1 y
-                             pokeElemOff ptr' 2 z
-                             pokeElemOff ptr' 3 w
-    where ptr' = castPtr ptr
-  {-# INLINE poke #-}
-  peek ptr = V4 <$> peek ptr' <*> peekElemOff ptr' 1
-                <*> peekElemOff ptr' 2 <*> peekElemOff ptr' 3
-    where ptr' = castPtr ptr
-  {-# INLINE peek #-}
-
-instance Storable a => Storable (V2 a) where
-  sizeOf _ = 2 * sizeOf (undefined::a)
-  {-# INLINE sizeOf #-}
-  alignment _ = alignment (undefined::a)
-  {-# INLINE alignment #-}
-  poke ptr (V2 x y) = poke ptr' x >> pokeElemOff ptr' 1 y
-    where ptr' = castPtr ptr
-  {-# INLINE poke #-}
-  peek ptr = V2 <$> peek ptr' <*> peekElemOff ptr' 1
-    where ptr' = castPtr ptr
-  {-# INLINE peek #-}
-
-instance Num a => Num (V2 a) where
-    (+) = liftA2 (+)
-    (-) = liftA2 (-)
-    (*) = liftA2 (*)
-    negate = fmap negate
-    abs = fmap abs
-    signum = fmap signum
-    fromInteger = pure . fromInteger
+#if defined(nolinear)
+import SDL.Internal.Vect as Vect
+#else
+import Linear as Vect
+import Linear.Affine as Vect
+#endif

--- a/src/SDL/Vect.hs
+++ b/src/SDL/Vect.hs
@@ -1,4 +1,10 @@
 {-# LANGUAGE CPP #-}
+
+-- | SDL's vector representation.
+--
+-- By default, re-exports the vector types from the 'linear' package, but this can be changed via the @-no-linear@
+-- build flag to export SDL's internal vector types from "SDL.Internal.Vect".
+-- This is useful if one does not want to incur the 'lens' dependency.
 module SDL.Vect
   ( module Vect
   ) where

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -113,7 +113,7 @@ createWindow title config = liftIO $ do
     let create' (V2 w h) = case windowPosition config of
           Centered -> let u = Raw.SDL_WINDOWPOS_CENTERED in create u u w h
           Wherever -> let u = Raw.SDL_WINDOWPOS_UNDEFINED in create u u w h
-          Absolute ((V2 x y)) -> create x y w h
+          Absolute (P (V2 x y)) -> create x y w h
     create' (windowInitialSize config) flags >>= return . Window
   where
     flags = foldr (.|.) 0
@@ -216,7 +216,7 @@ instance FromNumber WindowMode Word32 where
 data WindowPosition
   = Centered
   | Wherever -- ^ Let the window mananger decide where it's best to place the window.
-  | Absolute (V2 CInt)
+  | Absolute (Point V2 CInt)
   deriving (Eq, Generic, Ord, Read, Show, Typeable)
 
 -- | Destroy the given window. The 'Window' handler may not be used
@@ -276,7 +276,7 @@ setWindowPosition :: MonadIO m => Window -> WindowPosition -> m ()
 setWindowPosition (Window w) pos = case pos of
   Centered -> let u = Raw.SDL_WINDOWPOS_CENTERED in Raw.setWindowPosition w u u
   Wherever -> let u = Raw.SDL_WINDOWPOS_UNDEFINED in Raw.setWindowPosition w u u
-  Absolute ((V2 x y)) -> Raw.setWindowPosition w x y
+  Absolute (P (V2 x y)) -> Raw.setWindowPosition w x y
 
 -- | Get the position of the window.
 getWindowAbsolutePosition :: MonadIO m => Window -> m (V2 CInt)
@@ -351,7 +351,7 @@ getWindowConfig (Window w) = do
       , windowMode         = fromNumber wFlags
         -- Should we store the openGL config that was used to create the window?
       , windowOpenGL       = Nothing
-      , windowPosition     = Absolute (wPos)
+      , windowPosition     = Absolute (P wPos)
       , windowResizable    = wFlags .&. Raw.SDL_WINDOW_RESIZABLE > 0
       , windowInitialSize  = wSize
     }
@@ -450,7 +450,7 @@ windowGammaRamp (Window w) = makeStateVar getWindowGammaRamp setWindowGammaRamp
 
 data Display = Display {
                displayName           :: String
-             , displayBoundsPosition :: V2 CInt
+             , displayBoundsPosition :: Point V2 CInt
                  -- ^ Position of the desktop area represented by the display,
                  -- with the primary display located at @(0, 0)@.
              , displayBoundsSize     :: V2 CInt
@@ -505,7 +505,7 @@ getDisplays = liftIO $ do
 
     return $ Display {
         displayName = name'
-      , displayBoundsPosition = (V2 x y)
+      , displayBoundsPosition = P (V2 x y)
       , displayBoundsSize = V2 w h
       , displayModes = modes
     }

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -87,8 +87,7 @@ import Data.Typeable
 import Foreign hiding (void, throwIfNull, throwIfNeg, throwIfNeg_)
 import Foreign.C
 import GHC.Generics (Generic)
-import Linear
-import Linear.Affine (Point(P))
+import SDL.Vect
 import SDL.Exception
 import SDL.Internal.Numbered
 import SDL.Internal.Types
@@ -114,7 +113,7 @@ createWindow title config = liftIO $ do
     let create' (V2 w h) = case windowPosition config of
           Centered -> let u = Raw.SDL_WINDOWPOS_CENTERED in create u u w h
           Wherever -> let u = Raw.SDL_WINDOWPOS_UNDEFINED in create u u w h
-          Absolute (P (V2 x y)) -> create x y w h
+          Absolute ((V2 x y)) -> create x y w h
     create' (windowInitialSize config) flags >>= return . Window
   where
     flags = foldr (.|.) 0
@@ -217,7 +216,7 @@ instance FromNumber WindowMode Word32 where
 data WindowPosition
   = Centered
   | Wherever -- ^ Let the window mananger decide where it's best to place the window.
-  | Absolute (Point V2 CInt)
+  | Absolute (V2 CInt)
   deriving (Eq, Generic, Ord, Read, Show, Typeable)
 
 -- | Destroy the given window. The 'Window' handler may not be used
@@ -277,7 +276,7 @@ setWindowPosition :: MonadIO m => Window -> WindowPosition -> m ()
 setWindowPosition (Window w) pos = case pos of
   Centered -> let u = Raw.SDL_WINDOWPOS_CENTERED in Raw.setWindowPosition w u u
   Wherever -> let u = Raw.SDL_WINDOWPOS_UNDEFINED in Raw.setWindowPosition w u u
-  Absolute (P (V2 x y)) -> Raw.setWindowPosition w x y
+  Absolute ((V2 x y)) -> Raw.setWindowPosition w x y
 
 -- | Get the position of the window.
 getWindowAbsolutePosition :: MonadIO m => Window -> m (V2 CInt)
@@ -352,7 +351,7 @@ getWindowConfig (Window w) = do
       , windowMode         = fromNumber wFlags
         -- Should we store the openGL config that was used to create the window?
       , windowOpenGL       = Nothing
-      , windowPosition     = Absolute (P wPos)
+      , windowPosition     = Absolute (wPos)
       , windowResizable    = wFlags .&. Raw.SDL_WINDOW_RESIZABLE > 0
       , windowInitialSize  = wSize
     }
@@ -451,7 +450,7 @@ windowGammaRamp (Window w) = makeStateVar getWindowGammaRamp setWindowGammaRamp
 
 data Display = Display {
                displayName           :: String
-             , displayBoundsPosition :: Point V2 CInt
+             , displayBoundsPosition :: V2 CInt
                  -- ^ Position of the desktop area represented by the display,
                  -- with the primary display located at @(0, 0)@.
              , displayBoundsSize     :: V2 CInt
@@ -506,7 +505,7 @@ getDisplays = liftIO $ do
 
     return $ Display {
         displayName = name'
-      , displayBoundsPosition = P (V2 x y)
+      , displayBoundsPosition = (V2 x y)
       , displayBoundsSize = V2 w h
       , displayModes = modes
     }

--- a/src/SDL/Video/OpenGL.hs
+++ b/src/SDL/Video/OpenGL.hs
@@ -32,7 +32,7 @@ import Data.StateVar
 import Data.Typeable
 import Foreign.C.Types
 import GHC.Generics (Generic)
-import Linear
+import SDL.Vect
 import SDL.Exception
 import SDL.Internal.Numbered
 import SDL.Internal.Types

--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -152,7 +152,7 @@ surfaceBlit :: MonadIO m
             => Surface -- ^ The 'Surface' to be copied from
             -> Maybe (Rectangle CInt) -- ^ The rectangle to be copied, or 'Nothing' to copy the entire surface
             -> Surface -- ^ The 'Surface' that is the blit target
-            -> Maybe (V2 CInt) -- ^ The position to blit to
+            -> Maybe (Point V2 CInt) -- ^ The position to blit to
             -> m ()
 surfaceBlit (Surface src _) srcRect (Surface dst _) dstLoc = liftIO $
   throwIfNeg_ "SDL.Video.blitSurface" "SDL_BlitSurface" $
@@ -549,7 +549,7 @@ instance ToNumber BlendMode Word32 where
   toNumber BlendAdditive = Raw.SDL_BLENDMODE_ADD
   toNumber BlendMod = Raw.SDL_BLENDMODE_MOD
 
-data Rectangle a = Rectangle (V2 a) (V2 a)
+data Rectangle a = Rectangle (Point V2 a) (V2 a)
   deriving (Eq, Functor, Generic, Ord, Read, Show, Typeable)
 
 instance Storable a => Storable (Rectangle a) where
@@ -721,7 +721,7 @@ copyEx :: MonadIO m
        -> Maybe (Rectangle CInt) -- ^ The source rectangle to copy, or 'Nothing' for the whole texture
        -> Maybe (Rectangle CInt) -- ^ The destination rectangle to copy to, or 'Nothing' for the whole rendering target. The texture will be stretched to fill the given rectangle.
        -> CDouble -- ^ An angle in degrees that indicates the point around which the destination rectangle will be rotated.
-       -> Maybe (V2 CInt) -- ^ The point of rotation
+       -> Maybe (Point V2 CInt) -- ^ The point of rotation
        -> V2 Bool -- ^ Whether to flip in the X or Y axis.
        -> m () -- ^ Whether to flip in the X or Y axis.
 copyEx (Renderer r) (Texture t) srcRect dstRect theta center flips =
@@ -740,10 +740,10 @@ copyEx (Renderer r) (Texture t) srcRect dstRect theta center flips =
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawLine SDL_RenderDrawLine>@ for C documentation.
 drawLine :: (Functor m,MonadIO m)
          => Renderer
-         -> V2 CInt -- ^ The start point of the line
-         -> V2 CInt -- ^ The end point of the line
+         -> Point V2 CInt -- ^ The start point of the line
+         -> Point V2 CInt -- ^ The end point of the line
          -> m ()
-drawLine (Renderer r) ((V2 x y)) ((V2 x' y')) =
+drawLine (Renderer r) (P (V2 x y)) (P (V2 x' y')) =
   throwIfNeg_ "SDL.Video.drawLine" "SDL_RenderDrawLine" $
   Raw.renderDrawLine r x y x' y'
 
@@ -752,7 +752,7 @@ drawLine (Renderer r) ((V2 x y)) ((V2 x' y')) =
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawLines SDL_RenderDrawLines>@ for C documentation.
 drawLines :: MonadIO m
           => Renderer
-          -> SV.Vector (V2 CInt) -- ^ A 'SV.Vector' of points along the line. SDL will draw lines between these points.
+          -> SV.Vector (Point V2 CInt) -- ^ A 'SV.Vector' of points along the line. SDL will draw lines between these points.
           -> m ()
 drawLines (Renderer r) points =
   liftIO $
@@ -765,15 +765,15 @@ drawLines (Renderer r) points =
 -- | Draw a point on the current rendering target.
 --
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawPoint SDL_RenderDrawPoint>@ for C documentation.
-drawPoint :: (Functor m, MonadIO m) => Renderer -> V2 CInt -> m ()
-drawPoint (Renderer r) (V2 x y) =
+drawPoint :: (Functor m, MonadIO m) => Renderer -> Point V2 CInt -> m ()
+drawPoint (Renderer r) (P (V2 x y)) =
   throwIfNeg_ "SDL.Video.drawPoint" "SDL_RenderDrawPoint" $
   Raw.renderDrawPoint r x y
 
 -- | Draw multiple points on the current rendering target.
 --
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawPoints SDL_RenderDrawPoints>@ for C documentation.
-drawPoints :: MonadIO m => Renderer -> SV.Vector (V2 CInt) -> m ()
+drawPoints :: MonadIO m => Renderer -> SV.Vector (Point V2 CInt) -> m ()
 drawPoints (Renderer r) points =
   liftIO $
   throwIfNeg_ "SDL.Video.drawPoints" "SDL_RenderDrawPoints" $

--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -129,9 +129,8 @@ import Foreign.Marshal.Utils
 import Foreign.Ptr
 import Foreign.Storable
 import GHC.Generics (Generic)
-import Linear
-import Linear.Affine (Point(P))
 import Prelude hiding (foldr)
+import SDL.Vect
 import SDL.Exception
 import SDL.Internal.Numbered
 import SDL.Internal.Types
@@ -153,7 +152,7 @@ surfaceBlit :: MonadIO m
             => Surface -- ^ The 'Surface' to be copied from
             -> Maybe (Rectangle CInt) -- ^ The rectangle to be copied, or 'Nothing' to copy the entire surface
             -> Surface -- ^ The 'Surface' that is the blit target
-            -> Maybe (Point V2 CInt) -- ^ The position to blit to
+            -> Maybe (V2 CInt) -- ^ The position to blit to
             -> m ()
 surfaceBlit (Surface src _) srcRect (Surface dst _) dstLoc = liftIO $
   throwIfNeg_ "SDL.Video.blitSurface" "SDL_BlitSurface" $
@@ -550,7 +549,7 @@ instance ToNumber BlendMode Word32 where
   toNumber BlendAdditive = Raw.SDL_BLENDMODE_ADD
   toNumber BlendMod = Raw.SDL_BLENDMODE_MOD
 
-data Rectangle a = Rectangle (Point V2 a) (V2 a)
+data Rectangle a = Rectangle (V2 a) (V2 a)
   deriving (Eq, Functor, Generic, Ord, Read, Show, Typeable)
 
 instance Storable a => Storable (Rectangle a) where
@@ -722,7 +721,7 @@ copyEx :: MonadIO m
        -> Maybe (Rectangle CInt) -- ^ The source rectangle to copy, or 'Nothing' for the whole texture
        -> Maybe (Rectangle CInt) -- ^ The destination rectangle to copy to, or 'Nothing' for the whole rendering target. The texture will be stretched to fill the given rectangle.
        -> CDouble -- ^ An angle in degrees that indicates the point around which the destination rectangle will be rotated.
-       -> Maybe (Point V2 CInt) -- ^ The point of rotation
+       -> Maybe (V2 CInt) -- ^ The point of rotation
        -> V2 Bool -- ^ Whether to flip in the X or Y axis.
        -> m () -- ^ Whether to flip in the X or Y axis.
 copyEx (Renderer r) (Texture t) srcRect dstRect theta center flips =
@@ -741,10 +740,10 @@ copyEx (Renderer r) (Texture t) srcRect dstRect theta center flips =
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawLine SDL_RenderDrawLine>@ for C documentation.
 drawLine :: (Functor m,MonadIO m)
          => Renderer
-         -> Point V2 CInt -- ^ The start point of the line
-         -> Point V2 CInt -- ^ The end point of the line
+         -> V2 CInt -- ^ The start point of the line
+         -> V2 CInt -- ^ The end point of the line
          -> m ()
-drawLine (Renderer r) (P (V2 x y)) (P (V2 x' y')) =
+drawLine (Renderer r) ((V2 x y)) ((V2 x' y')) =
   throwIfNeg_ "SDL.Video.drawLine" "SDL_RenderDrawLine" $
   Raw.renderDrawLine r x y x' y'
 
@@ -753,7 +752,7 @@ drawLine (Renderer r) (P (V2 x y)) (P (V2 x' y')) =
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawLines SDL_RenderDrawLines>@ for C documentation.
 drawLines :: MonadIO m
           => Renderer
-          -> SV.Vector (Point V2 CInt) -- ^ A 'SV.Vector' of points along the line. SDL will draw lines between these points.
+          -> SV.Vector (V2 CInt) -- ^ A 'SV.Vector' of points along the line. SDL will draw lines between these points.
           -> m ()
 drawLines (Renderer r) points =
   liftIO $
@@ -766,15 +765,15 @@ drawLines (Renderer r) points =
 -- | Draw a point on the current rendering target.
 --
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawPoint SDL_RenderDrawPoint>@ for C documentation.
-drawPoint :: (Functor m, MonadIO m) => Renderer -> Point V2 CInt -> m ()
-drawPoint (Renderer r) (P (V2 x y)) =
+drawPoint :: (Functor m, MonadIO m) => Renderer -> V2 CInt -> m ()
+drawPoint (Renderer r) (V2 x y) =
   throwIfNeg_ "SDL.Video.drawPoint" "SDL_RenderDrawPoint" $
   Raw.renderDrawPoint r x y
 
 -- | Draw multiple points on the current rendering target.
 --
 -- See @<https://wiki.libsdl.org/SDL_RenderDrawPoints SDL_RenderDrawPoints>@ for C documentation.
-drawPoints :: MonadIO m => Renderer -> SV.Vector (Point V2 CInt) -> m ()
+drawPoints :: MonadIO m => Renderer -> SV.Vector (V2 CInt) -> m ()
 drawPoints (Renderer r) points =
   liftIO $
   throwIfNeg_ "SDL.Video.drawPoints" "SDL_RenderDrawPoints" $


### PR DESCRIPTION
Hey there, I was looking to move from GLFW to SDL2, but after seeing the linear/lens dependency I was somewhat put off, since I don't think there is any reason why a low-level library such as this should incur such a large dependency. Furthermore, it seems like very little of the linear package is used: the Storable instances, and the V2, V3, V4 types.

By doing this, we remove the lens dependency too, and a few dozen other packages. The vector functionality needed (which is very little) is in SDL.Vect.

I'm still not convinced SDL even needs a real vector type though, since the amount of vector math is very minimal.

Is this something you would consider?

Thanks

## Issues

- ~~I've only tested this on GHC 8.0.1, there are some errors on 7.8.3.~~
- ~~Points and Vectors are no longer distinguished. This can be fixed.~~
- ~~The new vector type has the same name as `linear`'s `V2`. Perhaps exposing a different type name to the user might be a good idea, or simply exposing naked values.~~
- ~~Documentation for Vect module is missing.~~