### PR TITLE
surfaceBlit returns the clipped dest rect

### DIFF
--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -156,12 +156,13 @@ surfaceBlit :: MonadIO m
             -> Maybe (Rectangle CInt) -- ^ The rectangle to be copied, or 'Nothing' to copy the entire surface
             -> Surface -- ^ The 'Surface' that is the blit target
             -> Maybe (Point V2 CInt) -- ^ The position to blit to
-            -> m ()
+            -> m (Maybe (Rectangle CInt))
 surfaceBlit (Surface src _) srcRect (Surface dst _) dstLoc = liftIO $
-  throwIfNeg_ "SDL.Video.blitSurface" "SDL_BlitSurface" $
   maybeWith with srcRect $ \srcPtr ->
-  maybeWith with (fmap (flip Rectangle 0) dstLoc) $ \dstPtr ->
-  Raw.blitSurface src (castPtr srcPtr) dst (castPtr dstPtr)
+  maybeWith with (fmap (flip Rectangle 0) dstLoc) $ \dstPtr -> do
+      throwIfNeg "SDL.Video.blitSurface" "SDL_BlitSurface" $
+          Raw.blitSurface src (castPtr srcPtr) dst (castPtr dstPtr)
+      maybe (pure Nothing) (\_ -> Just <$> peek dstPtr) dstLoc
 
 -- | Create a texture for a rendering context.
 --


### PR DESCRIPTION
According to the C docs, [`SDL_BlitSurface`](https://wiki.libsdl.org/SDL_BlitSurface) returns the clipped destination rectangle in case of `dstrect != NULL`. Even though fixing this implies a certain performance penalty because of the additional `peek` it should nevertheless be done in order to be compatible with the original library (or shouldn't it perhaps?).
