### PR TITLE
Update joystick POV hat support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+2.2.0
+=====
+
+* Add joystick POV hat support
+
 2.1.3
 =====
 

--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -1,5 +1,5 @@
 name:                sdl2
-version:             2.1.3
+version:             2.2.0
 synopsis:            Both high- and low-level bindings to the SDL library (version 2.0.2+).
 description:
   This package contains bindings to the SDL 2 library, in both high- and

--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -81,6 +81,7 @@ import Foreign
 import Foreign.C
 import GHC.Generics (Generic)
 import SDL.Vect
+import SDL.Input.Joystick
 import SDL.Input.Keyboard
 import SDL.Input.Mouse
 import SDL.Internal.Numbered
@@ -352,7 +353,7 @@ data JoyHatEventData =
                     -- ^ The instance id of the joystick that reported the event.
                   ,joyHatEventHat :: Word8
                    -- ^ The index of the hat that changed.
-                  ,joyHatEventValue :: Word8
+                  ,joyHatEventValue :: JoyHatPosition
                    -- ^ The new position of the hat.
                   }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -625,7 +626,11 @@ convertRaw (Raw.JoyBallEvent _ ts a b c d) =
                                      b
                                      (V2 c d))))
 convertRaw (Raw.JoyHatEvent _ ts a b c) =
-  return (Event ts (JoyHatEvent (JoyHatEventData a b c)))
+  return (Event ts
+                (JoyHatEvent
+                   (JoyHatEventData a
+                                    b
+                                    (fromNumber c))))
 convertRaw (Raw.JoyButtonEvent _ ts a b c) =
   return (Event ts (JoyButtonEvent (JoyButtonEventData a b c)))
 convertRaw (Raw.JoyDeviceEvent _ ts a) =


### PR DESCRIPTION
- Adds bindings for SDL_JoystickGetHat, SDL_JoystickNumHats
- Replace the JoyHatEventData Word8 value with an ADT

This is a breaking change because of the JoyHatEventData change, let me know if there's a version number or something that needs to be bumped

I tested this manually w/ a wired Xbox One controller on 64-bit Windows 10 and SDL2 2.0.5, everything works as expected