### PR TITLE
Add a cpp-options workaround for windows

### DIFF
--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -136,6 +136,9 @@ library
   default-language:
     Haskell2010
 
+  if os(windows)
+    cpp-options: -D_SDL_main_h
+
 executable lazyfoo-lesson-01
   if flag(examples)
     build-depends: base, sdl2


### PR DESCRIPTION
I've added and tested (-fexamples) this workaround: https://github.com/haskell-game/sdl2/issues/139