### PR TITLE
Resolve an unused-do-bind warning.

### DIFF
--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -159,8 +159,8 @@ surfaceBlit :: MonadIO m
 surfaceBlit (Surface src _) srcRect (Surface dst _) dstLoc = liftIO $
   maybeWith with srcRect $ \srcPtr ->
   maybeWith with (fmap (flip Rectangle 0) dstLoc) $ \dstPtr -> do
-      throwIfNeg "SDL.Video.blitSurface" "SDL_BlitSurface" $
-          Raw.blitSurface src (castPtr srcPtr) dst (castPtr dstPtr)
+      _ <- throwIfNeg "SDL.Video.blitSurface" "SDL_BlitSurface" $
+           Raw.blitSurface src (castPtr srcPtr) dst (castPtr dstPtr)
       maybe (pure Nothing) (\_ -> Just <$> peek dstPtr) dstLoc
 
 -- | Create a texture for a rendering context.


### PR DESCRIPTION
Resolves the following warning:

```
sdl2/src/SDL/Video/Renderer.hs:162:7: warning: [-Wunused-do-bind]
    A do-notation statement discarded a result of type ‘CInt’
    Suppress this warning by saying
      ‘_ <- ($)
              throwIfNeg "SDL.Video.blitSurface" "SDL_BlitSurface"
              Raw.blitSurface src (castPtr srcPtr) dst (castPtr dstPtr)’
```