### PR TITLE
use FromNumber for MouseButton

### DIFF
--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -611,19 +611,12 @@ convertRaw (Raw.MouseButtonEvent t ts a b c _ e f g) =
            | t == Raw.SDL_MOUSEBUTTONUP = Released
            | t == Raw.SDL_MOUSEBUTTONDOWN = Pressed
            | otherwise = error "convertRaw: Unexpected mouse button motion"
-         button
-           | c == Raw.SDL_BUTTON_LEFT = ButtonLeft
-           | c == Raw.SDL_BUTTON_MIDDLE = ButtonMiddle
-           | c == Raw.SDL_BUTTON_RIGHT = ButtonRight
-           | c == Raw.SDL_BUTTON_X1 = ButtonX1
-           | c == Raw.SDL_BUTTON_X2 = ButtonX2
-           | otherwise = ButtonExtra $ fromIntegral c
      return (Event ts
                    (MouseButtonEvent
                       (MouseButtonEventData w'
                                             motion
                                             (fromNumber b)
-                                            button
+                                            (fromNumber c)
                                             e
                                             (P (V2 f g)))))
 convertRaw (Raw.MouseWheelEvent _ ts a b c d e) =

--- a/src/SDL/Input/Mouse.hs
+++ b/src/SDL/Input/Mouse.hs
@@ -99,6 +99,14 @@ data MouseButton
   | ButtonExtra !Int -- ^ An unknown mouse button.
   deriving (Data, Eq, Generic, Ord, Read, Show, Typeable)
 
+instance FromNumber MouseButton Word8 where
+  fromNumber Raw.SDL_BUTTON_LEFT   = ButtonLeft
+  fromNumber Raw.SDL_BUTTON_MIDDLE = ButtonMiddle
+  fromNumber Raw.SDL_BUTTON_RIGHT  = ButtonRight
+  fromNumber Raw.SDL_BUTTON_X1     = ButtonX1
+  fromNumber Raw.SDL_BUTTON_X2     = ButtonX2
+  fromNumber buttonCode            = ButtonExtra $ fromIntegral buttonCode
+
 -- | Identifies what kind of mouse-like device this is.
 data MouseDevice
   = Mouse !Int -- ^ An actual mouse. The number identifies which mouse.


### PR DESCRIPTION
Implements `FromNumber` for `MouseButton` and uses it when converting
events.

Some context: I've been working on code to implement `pushEvent`, which of course involves converting events in the other direction, where `ToNumber` becomes quite useful. This preliminary change struck me as being in keeping with how the project is generally addressing type conversions from the FFI.