### PR TITLE
breaking: high-level JoyButtonState structure

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@ Unreleased
 
 * Windows builds now use `-D_SDL_main_h`. See https://github.com/haskell-game/sdl2/issues/139 for more discussion.
 * Support for event watching: `addEventWatch` and `delEventWatch`.
+* High-level structure for joystick button state: `JoyButtonState`.
 
 2.2.0
 =====

--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -373,7 +373,7 @@ data JoyButtonEventData =
                       -- ^ The instance id of the joystick that reported the event.
                      ,joyButtonEventButton :: !Word8
                       -- ^ The index of the button that changed.
-                     ,joyButtonEventState :: !Word8
+                     ,joyButtonEventState :: !JoyButtonState
                       -- ^ The state of the button.
                      }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -649,7 +649,7 @@ convertRaw (Raw.JoyHatEvent _ ts a b c) =
                                     b
                                     (fromNumber c))))
 convertRaw (Raw.JoyButtonEvent _ ts a b c) =
-  return (Event ts (JoyButtonEvent (JoyButtonEventData a b c)))
+  return (Event ts (JoyButtonEvent (JoyButtonEventData a b (fromNumber c))))
 convertRaw (Raw.JoyDeviceEvent _ ts a) =
   return (Event ts (JoyDeviceEvent (JoyDeviceEventData a)))
 convertRaw (Raw.ControllerAxisEvent _ ts a b c) =

--- a/src/SDL/Input/Joystick.hs
+++ b/src/SDL/Input/Joystick.hs
@@ -15,6 +15,7 @@ module SDL.Input.Joystick
 
   , getJoystickID
   , Joystick
+  , JoyButtonState(..)
   , buttonPressed
   , ballDelta
   , axisPosition
@@ -56,6 +57,16 @@ data JoystickDevice = JoystickDevice
   { joystickDeviceName :: Text
   , joystickDeviceId :: CInt
   } deriving (Eq, Generic, Read, Ord, Show, Typeable)
+
+-- | Identifies the state of a joystick button.
+data JoyButtonState = JoyButtonPressed | JoyButtonReleased
+  deriving (Data, Eq, Generic, Ord, Read, Show, Typeable)
+
+instance FromNumber JoyButtonState Word8 where
+  fromNumber n = case n of
+    Raw.SDL_PRESSED -> JoyButtonPressed
+    Raw.SDL_RELEASED -> JoyButtonReleased
+    _ -> JoyButtonReleased
 
 -- | Count the number of joysticks attached to the system.
 --


### PR DESCRIPTION
According to https://wiki.libsdl.org/SDL_JoyButtonEvent#SDL_JoyButtonEvent-1 there are two possible button states for joystick buttons. Other high-level data structures in the library generally encode these in possibilities (see `JoyHatPosition`, for example).