### PR TITLE
breaking: High-level structure for joystick addition/removal.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@ Unreleased
 
 * Windows builds now use `-D_SDL_main_h`. See https://github.com/haskell-game/sdl2/issues/139 for more discussion.
 * Support for event watching: `addEventWatch` and `delEventWatch`.
+* High-level structure for joystick device connection: `JoyDeviceConnection`.
 
 2.2.0
 =====

--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -380,7 +380,9 @@ data JoyButtonEventData =
 
 -- | Joystick device event information.
 data JoyDeviceEventData =
-  JoyDeviceEventData {joyDeviceEventWhich :: !Int32
+  JoyDeviceEventData {joyDeviceEventConnection :: !JoyDeviceConnection
+                      -- ^ Was the device added or removed?
+                     ,joyDeviceEventWhich :: !Int32
                       -- ^ The instance id of the joystick that reported the event.
                      }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -650,8 +652,8 @@ convertRaw (Raw.JoyHatEvent _ ts a b c) =
                                     (fromNumber c))))
 convertRaw (Raw.JoyButtonEvent _ ts a b c) =
   return (Event ts (JoyButtonEvent (JoyButtonEventData a b c)))
-convertRaw (Raw.JoyDeviceEvent _ ts a) =
-  return (Event ts (JoyDeviceEvent (JoyDeviceEventData a)))
+convertRaw (Raw.JoyDeviceEvent t ts a) =
+  return (Event ts (JoyDeviceEvent (JoyDeviceEventData (fromNumber t) a)))
 convertRaw (Raw.ControllerAxisEvent _ ts a b c) =
   return (Event ts (ControllerAxisEvent (ControllerAxisEventData a b c)))
 convertRaw (Raw.ControllerButtonEvent _ ts a b c) =

--- a/src/SDL/Input/Joystick.hs
+++ b/src/SDL/Input/Joystick.hs
@@ -24,6 +24,7 @@ module SDL.Input.Joystick
   , JoyHatPosition(..)
   , getHat
   , numHats
+  , JoyDeviceConnection(..)
   ) where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -195,3 +196,13 @@ getHat (Joystick j) hatIndex = fromNumber <$> Raw.joystickGetHat j hatIndex
 -- See @<https://wiki.libsdl.org/https://wiki.libsdl.org/SDL_JoystickNumHats SDL_JoystickNumHats>@ for C documentation.
 numHats :: (MonadIO m) => Joystick -> m CInt
 numHats (Joystick j) = liftIO $ throwIfNeg "SDL.Input.Joystick.numHats" "SDL_JoystickNumHats" (Raw.joystickNumHats j)
+
+-- | Identifies whether a joystick has been connected or disconnected.
+data JoyDeviceConnection = JoyDeviceAdded | JoyDeviceRemoved
+  deriving (Data, Eq, Generic, Ord, Read, Show, Typeable)
+
+instance FromNumber JoyDeviceConnection Word32 where
+  fromNumber n = case n of
+    Raw.SDL_JOYDEVICEADDED -> JoyDeviceAdded
+    Raw.SDL_JOYDEVICEREMOVED -> JoyDeviceRemoved
+    _ -> JoyDeviceAdded


### PR DESCRIPTION
`JoyDeviceConnection` data structure. This information was being discarded from the `SDL_JoyDeviceEvent` structure.