### PR TITLE
Replace `not (null (filter ...))` with `any` in docs

### DIFF
--- a/src/SDL.hs
+++ b/src/SDL.hs
@@ -99,7 +99,7 @@ Here @events@ is a list of 'Event' values. For our application we will check if 
             'keyboardEventKeyMotion' keyboardEvent == 'Pressed' &&
             'keysymKeycode' ('keyboardEventKeysym' keyboardEvent) == 'KeycodeQ'
           _ -> False
-      qPressed = not (null (filter eventIsQPress events))
+      qPressed = any eventIsQPress events
 @
 
 In our @appLoop@ we process events and then update the screen accordingly. Here we simply use the 'Renderer'


### PR DESCRIPTION
This is related to #118. Part of the docs use `any` while another part uses `not (null (filter ...))`. This changes both cases to use `any`.