### PR TITLE
gamecontroller: Fix button pressed/release state

### DIFF
--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -680,12 +680,12 @@ convertRaw (Raw.JoyDeviceEvent t ts a) =
   return (Event ts (JoyDeviceEvent (JoyDeviceEventData (fromNumber t) a)))
 convertRaw (Raw.ControllerAxisEvent _ ts a b c) =
   return (Event ts (ControllerAxisEvent (ControllerAxisEventData a b c)))
-convertRaw (Raw.ControllerButtonEvent _ ts a b c) =
+convertRaw (Raw.ControllerButtonEvent t ts a b _) =
   return (Event ts 
            (ControllerButtonEvent
              (ControllerButtonEventData a 
                                         (fromNumber $ fromIntegral b)
-                                        (fromNumber c))))
+                                        (fromNumber t))))
 convertRaw (Raw.ControllerDeviceEvent t ts a) =
   return (Event ts (ControllerDeviceEvent (ControllerDeviceEventData (fromNumber t) a)))
 convertRaw (Raw.AudioDeviceEvent Raw.SDL_AUDIODEVICEADDED ts a b) =

--- a/src/SDL/Input/GameController.hs
+++ b/src/SDL/Input/GameController.hs
@@ -57,14 +57,17 @@ instance FromNumber ControllerButton Int32 where
     _ -> ControllerButtonInvalid
 
 -- | Identifies the state of a controller button.
-data ControllerButtonState = ControllerButtonPressed | ControllerButtonReleased
+data ControllerButtonState
+  = ControllerButtonPressed
+  | ControllerButtonReleased
+  | ControllerButtonInvalidState
   deriving (Data, Eq, Generic, Ord, Read, Show, Typeable)
 
-instance FromNumber ControllerButtonState Word8 where
+instance FromNumber ControllerButtonState Word32 where
   fromNumber n = case n of
-    Raw.SDL_PRESSED -> ControllerButtonPressed
-    Raw.SDL_RELEASED -> ControllerButtonReleased
-    _ -> ControllerButtonPressed
+    Raw.SDL_CONTROLLERBUTTONDOWN -> ControllerButtonPressed
+    Raw.SDL_CONTROLLERBUTTONUP -> ControllerButtonReleased
+    _ -> ControllerButtonInvalidState
 
 -- | Identified whether the game controller was added, removed, or remapped.
 data ControllerDeviceConnection


### PR DESCRIPTION
The SDL_PRESSED and SDL_RELEASED state doesn't seem to be very reliable for acquiring button states, because they seem to be fire also whenever the analog sticks are below threshold.

After looking at the SDL implementation it seems that the state value is passed and filtered around through multiple functions and almost always gets assigned to *some* value coming from the underlying joystick API:

http://hg.libsdl.org/SDL/file/084b3caa1bc8/src/joystick/SDL_gamecontroller.c

I've tested this on two game pads prior to this commit and when not touching the game pads at all I get SDL_PRESSED events even for buttons.

After testing this commit I get the expected behaviour, although I have only tested the D-pad and four buttons, not axis or hats.