### PR TITLE
Fixed off-by-one error in mouse button bit-masking

### DIFF
--- a/src/SDL/Input/Mouse.hs
+++ b/src/SDL/Input/Mouse.hs
@@ -203,7 +203,7 @@ getMouseButtons :: MonadIO m => m (MouseButton -> Bool)
 getMouseButtons = liftIO $
   convert <$> Raw.getMouseState nullPtr nullPtr
   where
-    convert w b = w `testBit` fromIntegral (toNumber b)
+    convert w b = w `testBit` fromIntegral (toNumber b - 1)
 
 newtype Cursor = Cursor { unwrapCursor :: Raw.Cursor }
     deriving (Eq, Typeable)


### PR DESCRIPTION
`getMouseButtons` detects the wrong buttons because its bit mask doesn't match SDL's convention. For example, it's impossible to detect the left mouse button being held.

[`getMouseState`](https://hackage.haskell.org/package/sdl2-2.4.0.1/docs/SDL-Raw-Event.html#v:getMouseState), like [`SDL_GetMouseState`](https://wiki.libsdl.org/SDL_GetMouseState), produces a set of Boolean flags encoded as the bits of an integer. We test the *n*th flag by AND-ing that integer with a bit mask: the integer 1 bit-shifted by *n* places.

The state of the left mouse button resides in the lowest-order bit—0 places away from the lowest place. So, to test that button we have to bit-shift by 0 places.

SDL provides the macro definitions `SDL_BUTTON(X)` and `SDL_BUTTON_LEFT` to do that bit-shifting. It defines `SDL_BUTTON_LEFT` to be 1, not 0, and it defines `SDL_BUTTON(X)` to subtract 1 from its argument before using it to construct the bit mask (see lines 203-204 in SDL_mouse.h):

    #define SDL_BUTTON(X)       (1 << ((X)-1))
    #define SDL_BUTTON_LEFT     1

So, `&& SDL_BUTTON( SDL_BUTTON_LEFT )` = `&& (1 << (1 - 1))` = `&& (1 << 0)`, which is what we want.

However, the corresponding Haskell provisions don't match that convention. `Raw.SDL_BUTTON_LEFT` (and hence `toNumber ButtonLeft`) is [defined to be 1](https://hackage.haskell.org/package/sdl2-2.4.0.1/docs/src/SDL-Raw-Enum.html#SDL_BUTTON_LEFT), but `getMouseButtons` [doesn't do the same subtraction](https://hackage.haskell.org/package/sdl2-2.4.0.1/docs/src/SDL-Input-Mouse.html#getMouseButtons) as `SDL_BUTTON(X)`:

    getMouseButtons = liftIO $
      convert <$> Raw.getMouseState nullPtr nullPtr
      where
        convert w b = w `testBit` fromIntegral (toNumber b)

Here, ```(`testBit` fromIntegral (toNumber ButtonLeft))``` = ```(`testBit` 1)```, but that doesn't test the left button. We want ```(`testBit` 0)```.