### PR TITLE
Adding a Get Started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+This package provides Haskell bindings for the SDL2 library.
+
+# What is SDL2?
+
+SDL (Simple DirectMedia Layer) is a library for cross-platform development of interactive applications.
+SDL provides routines for managing windows, rendering graphics, processing sound, collecting input data, and much more.
+
+The Haskell sdl2 library provides both a high- and low-level API to interface with SDL.
+
+You may also want to check out:
+
+- [sdl2-image](https://hackage.haskell.org/package/sdl2-image) - For handling different image formats such as `jpg` and `png`.
+- [sdl2-mixer](https://hackage.haskell.org/package/sdl2-mixer) - For playing audio.
+- [sdl2-gfx](https://hackage.haskell.org/package/sdl2-gfx) - For drawing graphics primitives such as circles and polygons.
+- [sdl2-ttf](https://hackage.haskell.org/package/sdl2-ttf) - For handling true type fonts.
+
+
 # Building
 
 [![Build Status](https://travis-ci.org/haskell-game/sdl2.svg?branch=master)](https://travis-ci.org/haskell-game/sdl2)
@@ -17,6 +34,10 @@ On OSX you can install SDL with [homebrew](http://brew.sh/). pkg-config is also 
 On Windows you can install SDL with `pacman` under [MSYS2](https://msys2.github.io/) (or use  [stack's embedded MSYS2](https://www.reddit.com/r/haskellgamedev/comments/4jpthu/windows_sdl2_is_now_almost_painless_via_stack/)).
 
     pacman -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-SDL2
+
+# Get Started
+
+Take a look at the [getting started guide](https://hackage.haskell.org/package/sdl2/docs/SDL.html).
 
 # Contributing
 

--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -12,6 +12,8 @@ description:
   Haskell FFI calls. As such, this does not contain sum types nor error
   checking. Thus this namespace is suitable for building your own abstraction
   over SDL, but is not recommended for day-to-day programming.
+  .
+  Read "SDL" for a getting started guide.
 
 license:             BSD3
 license-file:        LICENSE


### PR DESCRIPTION
This PR adds a short get started guide.

I tried explaining one of the first examples of lazyfoo's guide (example 3) and what the Haskell code is doing, and linked for [an example snake game](/soupi/sdl2-snake) I wrote to complement the guide.

I don't mind moving the example game to a different repository if needed.

Let me know if there's anything you'd like me to change.

Thanks!
