### PR TITLE
Add missing SDL module id for OpenGLContext

### DIFF
--- a/examples/OpenGLExample.hs
+++ b/examples/OpenGLExample.hs
@@ -31,7 +31,7 @@ main = do
     SDL.createWindow
       "SDL / OpenGL Example"
       SDL.defaultWindow {SDL.windowInitialSize = V2 screenWidth screenHeight,
-                         SDL.windowGraphicsContext = OpenGLContext SDL.defaultOpenGL}
+                         SDL.windowGraphicsContext = SDL.OpenGLContext SDL.defaultOpenGL}
   SDL.showWindow window
 
   _ <- SDL.glCreateContext window


### PR DESCRIPTION
The `SDL` module ID seems to have been missed for `OpenGLContext`. The OpenGL example wouldn't compile for me without this.

AFAICT, the examples are not included in the CI build, so it may have accidentally been omitted in this commit: https://github.com/haskell-game/sdl2/commit/eb40908f24a136dc6f35dbc27c7faed24efbd477