### PR TITLE
Expose ModalLocation type

### DIFF
--- a/src/SDL/Input/Mouse.hs
+++ b/src/SDL/Input/Mouse.hs
@@ -17,6 +17,7 @@ module SDL.Input.Mouse
   , MouseScrollDirection(..)
 
     -- * Mouse State
+  , ModalLocation(..)
   , getModalMouseLocation
   , getAbsoluteMouseLocation
   , getRelativeMouseLocation


### PR DESCRIPTION
fixes #206 

In [SDL.Input.Mouse](https://github.com/haskell-game/sdl2/blob/master/src/SDL/Input/Mouse.hs), the data type `ModalLocation` is not exported, meaning you cannot really access the result of the function `getModalMouseLocation`:

    getModalMouseLocation :: MonadIO m => m ModalLocation

This PR simply adds a line to export that type.