### PR TITLE
fix SDL_CONTROLLERAXISMOTION/ControllerAxisEvent

### DIFF
--- a/src/SDL/Raw/Types.hsc
+++ b/src/SDL/Raw/Types.hsc
@@ -545,7 +545,7 @@ instance Storable Event where
         which <- (#peek SDL_Event, caxis.which) ptr
         axis <- (#peek SDL_Event, caxis.axis) ptr
         value <- (#peek SDL_Event, caxis.value) ptr
-        return $! ControllerButtonEvent typ timestamp which axis value
+        return $! ControllerAxisEvent typ timestamp which axis value
       (#const SDL_CONTROLLERBUTTONDOWN) -> controllerbutton $ ControllerButtonEvent typ timestamp
       (#const SDL_CONTROLLERBUTTONUP) -> controllerbutton $ ControllerButtonEvent typ timestamp
       (#const SDL_CONTROLLERDEVICEADDED) -> controllerdevice $ ControllerDeviceEvent typ timestamp


### PR DESCRIPTION
Was wondering why `ControllerAxisEvent ` never fired, but moving gamepad analog sticks seemed to send `ControllerButtonEvent`.  This fixes that behavior, tested manually.