### PR TITLE
fix the sinSamples's frequecy to 440Hz

### DIFF
--- a/examples/AudioExample.hs
+++ b/examples/AudioExample.hs
@@ -13,8 +13,8 @@ sinSamples :: [Int16]
 sinSamples =
   map (\n ->
          let t = fromIntegral n / 48000 :: Double
-             freq = 440 * 4
-         in round (fromIntegral (maxBound `div` 2 :: Int16) * sin (t * freq)))
+             freq = 440
+         in round (fromIntegral (maxBound `div` 2 :: Int16) * sin (2 * pi * t * freq)))
       [0 :: Int32 ..]
 
 audioCB :: IORef [Int16] -> AudioFormat sampleType -> V.IOVector sampleType -> IO ()

--- a/examples/AudioExample.hs
+++ b/examples/AudioExample.hs
@@ -14,7 +14,7 @@ sinSamples =
   map (\n ->
          let t = fromIntegral n / 48000 :: Double
              freq = 440
-         in round (fromIntegral (maxBound `div` 2 :: Int16) * sin (2 * pi * t * freq)))
+         in round (fromIntegral (maxBound `div` 2 :: Int16) * sin (2 * pi * freq * t)))
       [0 :: Int32 ..]
 
 audioCB :: IORef [Int16] -> AudioFormat sampleType -> V.IOVector sampleType -> IO ()


### PR DESCRIPTION
Hi.
I tried your Audio tutorial, examples/AudioExample.hs.
But when I measured the sound's frequecy with tuner, the value is about 280Hz.

So I fix the 'sinSamples' function as user can get correct 440Hz sound.
The sound which frequency is f, the equation is following: 

sound = sin (2πft).

Please review this PR. Thank you.