### PR TITLE
Export `SurfacePixelFormat` constructor

### DIFF
--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -78,7 +78,7 @@ module SDL.Video.Renderer
   , paletteColors
   , paletteColor
   , PixelFormat(..)
-  , SurfacePixelFormat
+  , SurfacePixelFormat(..)
   , formatPalette
   , setPaletteColors
   , pixelFormatToMasks


### PR DESCRIPTION
There's no way to construct `SurfacePixelFormat`. This simple change make it possible to construct them, like this
```haskell
pixelFormat :: SDL.Raw.PixelFormat
pixelFormat = SDL.Raw.PixelFormat
  { SDL.Raw.pixelFormatFormat        = SDL.toNumber SDL.RGBA4444
  , SDL.Raw.pixelFormatPalette       = nullPtr
  , SDL.Raw.pixelFormatBitsPerPixel  = 32
  , SDL.Raw.pixelFormatBytesPerPixel = 4
  , SDL.Raw.pixelFormatRMask         = 0x000000ff
  , SDL.Raw.pixelFormatGMask         = 0x0000ff00
  , SDL.Raw.pixelFormatBMask         = 0x00ff0000
  , SDL.Raw.pixelFormatAMask         = 0xff000000
  }

withSurfacePixelFormat
  :: (MonadMask m, MonadUnliftIO m) => (SDL.SurfacePixelFormat -> m a) -> m a
withSurfacePixelFormat action = do
  pf <- liftIO mallocForeignPtr
  withRunInIO $ \runInIO -> do
    withForeignPtr pf $ \pf -> do
      poke pf pixelFormat
      runInIO . action $ SDL.SurfacePixelFormat pf

-- ...
  withSurfacePixelFormat $ \f -> do
    s' <- SDL.convertSurface someSurface f
-- ...

```

A way of constructing `SurfacePixelFormat` is required when a user needs to convert surface to specific format. e. g. I want to convert unknown type of surface to RGBA4444 before I tex them into OpenGL texture.

Example above seems to have too much hassle, so I tried to wrap `SDL.Raw.PixelFormat`. But it requires me to do something with `malloc` or something because `SDL.SurfacePixelFormat` requires pointer to `SDL.Raw.PixelFormat`, (and `alloca` is `IO` not `MonadIO` oh no).

So as long as not allocating memory in `SDL.Video.Renderer` this is best approach I can come up, any idea?