### PR TITLE
add bindings for renderCopyExF, FRect, FPoint

### DIFF
--- a/src/SDL/Raw/Types.hsc
+++ b/src/SDL/Raw/Types.hsc
@@ -66,7 +66,9 @@ module SDL.Raw.Types (
   Palette(..),
   PixelFormat(..),
   Point(..),
+  FPoint(..),
   Rect(..),
+  FRect(..),
   RendererInfo(..),
   RWops(..),
   Surface(..),
@@ -1332,6 +1334,22 @@ instance Storable Point where
     (#poke SDL_Point, x) ptr x
     (#poke SDL_Point, y) ptr y
 
+data FPoint = FPoint
+  { fPointX :: !CFloat
+  , fPointY :: !CFloat
+  } deriving (Eq, Show, Typeable)
+
+instance Storable FPoint where
+  sizeOf _ = (#size SDL_FPoint)
+  alignment = sizeOf
+  peek ptr = do
+    x <- (#peek SDL_FPoint, x) ptr
+    y <- (#peek SDL_FPoint, y) ptr
+    return $! FPoint x y
+  poke ptr (FPoint x y) = do
+    (#poke SDL_FPoint, x) ptr x
+    (#poke SDL_FPoint, y) ptr y
+
 data Rect = Rect
   { rectX :: !CInt
   , rectY :: !CInt
@@ -1353,6 +1371,28 @@ instance Storable Rect where
     (#poke SDL_Rect, y) ptr y
     (#poke SDL_Rect, w) ptr w
     (#poke SDL_Rect, h) ptr h
+
+data FRect = FRect
+  { fRectX :: !CFloat
+  , fRectY :: !CFloat
+  , fRectW :: !CFloat
+  , fRectH :: !CFloat
+  } deriving (Eq, Show, Typeable)
+
+instance Storable FRect where
+  sizeOf _ = (#size SDL_FRect)
+  alignment = sizeOf
+  peek ptr = do
+    x <- (#peek SDL_FRect, x) ptr
+    y <- (#peek SDL_FRect, y) ptr
+    w <- (#peek SDL_FRect, w) ptr
+    h <- (#peek SDL_FRect, h) ptr
+    return $! FRect x y w h
+  poke ptr (FRect x y w h) = do
+    (#poke SDL_FRect, x) ptr x
+    (#poke SDL_FRect, y) ptr y
+    (#poke SDL_FRect, w) ptr w
+    (#poke SDL_FRect, h) ptr h
 
 data RendererInfo = RendererInfo
   { rendererInfoName :: !CString

--- a/src/SDL/Raw/Video.hs
+++ b/src/SDL/Raw/Video.hs
@@ -106,6 +106,7 @@ module SDL.Raw.Video (
   renderClear,
   renderCopy,
   renderCopyEx,
+  renderCopyExF,
   renderDrawLine,
   renderDrawLines,
   renderDrawPoint,
@@ -323,6 +324,7 @@ foreign import ccall "SDL.h SDL_QueryTexture" queryTextureFFI :: Texture -> Ptr 
 foreign import ccall "SDL.h SDL_RenderClear" renderClearFFI :: Renderer -> IO CInt
 foreign import ccall "SDL.h SDL_RenderCopy" renderCopyFFI :: Renderer -> Texture -> Ptr Rect -> Ptr Rect -> IO CInt
 foreign import ccall "SDL.h SDL_RenderCopyEx" renderCopyExFFI :: Renderer -> Texture -> Ptr Rect -> Ptr Rect -> CDouble -> Ptr Point -> RendererFlip -> IO CInt
+foreign import ccall "SDL.h SDL_RenderCopyExF" renderCopyExFFFI :: Renderer -> Texture -> Ptr Rect -> Ptr FRect -> CDouble -> Ptr FPoint -> RendererFlip -> IO CInt
 foreign import ccall "SDL.h SDL_RenderDrawLine" renderDrawLineFFI :: Renderer -> CInt -> CInt -> CInt -> CInt -> IO CInt
 foreign import ccall "SDL.h SDL_RenderDrawLines" renderDrawLinesFFI :: Renderer -> Ptr Point -> CInt -> IO CInt
 foreign import ccall "SDL.h SDL_RenderDrawPoint" renderDrawPointFFI :: Renderer -> CInt -> CInt -> IO CInt
@@ -832,6 +834,10 @@ renderCopy v1 v2 v3 v4 = liftIO $ renderCopyFFI v1 v2 v3 v4
 renderCopyEx :: MonadIO m => Renderer -> Texture -> Ptr Rect -> Ptr Rect -> CDouble -> Ptr Point -> RendererFlip -> m CInt
 renderCopyEx v1 v2 v3 v4 v5 v6 v7 = liftIO $ renderCopyExFFI v1 v2 v3 v4 v5 v6 v7
 {-# INLINE renderCopyEx #-}
+
+renderCopyExF :: MonadIO m => Renderer -> Texture -> Ptr Rect -> Ptr FRect -> CDouble -> Ptr FPoint -> RendererFlip -> m CInt
+renderCopyExF v1 v2 v3 v4 v5 v6 v7 = liftIO $ renderCopyExFFFI v1 v2 v3 v4 v5 v6 v7
+{-# INLINE renderCopyExF #-}
 
 renderDrawLine :: MonadIO m => Renderer -> CInt -> CInt -> CInt -> CInt -> m CInt
 renderDrawLine v1 v2 v3 v4 v5 = liftIO $ renderDrawLineFFI v1 v2 v3 v4 v5

--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -23,6 +23,7 @@ module SDL.Video.Renderer
   , clear
   , copy
   , copyEx
+  , copyExF
   , drawLine
   , drawLines
   , drawPoint
@@ -760,6 +761,27 @@ copyEx (Renderer r) (Texture t) srcRect dstRect theta center flips =
   maybeWith with dstRect $ \dst ->
   maybeWith with center $ \c ->
   Raw.renderCopyEx r t (castPtr src) (castPtr dst) theta (castPtr c)
+                   (case flips of
+                      V2 x y -> (if x then Raw.SDL_FLIP_HORIZONTAL else 0) .|.
+                               (if y then Raw.SDL_FLIP_VERTICAL else 0))
+
+-- | Copy a portion of the texture to the current rendering target, optionally rotating it by angle around the given center and also flipping it top-bottom and/or left-right.
+copyExF :: MonadIO m
+       => Renderer -- ^ The rendering context
+       -> Texture -- ^ The source texture
+       -> Maybe (Rectangle CInt) -- ^ The source rectangle to copy, or 'Nothing' for the whole texture
+       -> Maybe (Rectangle CFloat) -- ^ The destination rectangle to copy to, or 'Nothing' for the whole rendering target. The texture will be stretched to fill the given rectangle.
+       -> CDouble -- ^ The angle of rotation in degrees. The rotation will be performed clockwise.
+       -> Maybe (Point V2 CFloat) -- ^ The point indicating the center of the rotation, or 'Nothing' to rotate around the center of the destination rectangle
+       -> V2 Bool -- ^ Whether to flip the texture on the X and/or Y axis
+       -> m ()
+copyExF (Renderer r) (Texture t) srcRect dstRect theta center flips =
+  liftIO $
+  throwIfNeg_ "SDL.Video.copyExF" "SDL_RenderCopyExF" $
+  maybeWith with srcRect $ \src ->
+  maybeWith with dstRect $ \dst ->
+  maybeWith with center $ \c ->
+  Raw.renderCopyExF r t (castPtr src) (castPtr dst) theta (castPtr c)
                    (case flips of
                       V2 x y -> (if x then Raw.SDL_FLIP_HORIZONTAL else 0) .|.
                                (if y then Raw.SDL_FLIP_VERTICAL else 0))


### PR DESCRIPTION
The SDL_RenderCopyExF() function is undocumented but needed to draw textures at floating point coordinates, this is useful to avoid rounding issues when rendering.  It was added in https://github.com/libsdl-org/SDL/commit/8340b0f0e2b84957e2eee444ae83b6b506d9b15d (Oct 22, 2018) and the interface seems to have been stable since?

Tested this out manually on Windows 10 (64-bit), Arch Linux (x86-64), and macOS 10.13.6.