### PR TITLE
SDL.Audio: Fix openAudioDevice Changeable check

### DIFF
--- a/src/SDL/Audio.hs
+++ b/src/SDL/Audio.hs
@@ -175,9 +175,9 @@ openAudioDevice OpenDeviceSpec{..} = liftIO $
         return (audioDevice, spec)
 
   where
-  changes = foldl (.|.) 0 [ foldChangeable (const Raw.SDL_AUDIO_ALLOW_FREQUENCY_CHANGE) (const 0) openDeviceFreq
-                          , foldChangeable (const Raw.SDL_AUDIO_ALLOW_FORMAT_CHANGE) (const 0) openDeviceFormat
-                          , foldChangeable (const Raw.SDL_AUDIO_ALLOW_CHANNELS_CHANGE) (const 0) openDeviceChannels
+  changes = foldl (.|.) 0 [ foldChangeable (const 0) (const Raw.SDL_AUDIO_ALLOW_FREQUENCY_CHANGE) openDeviceFreq
+                          , foldChangeable (const 0) (const Raw.SDL_AUDIO_ALLOW_FORMAT_CHANGE) openDeviceFormat
+                          , foldChangeable (const 0) (const Raw.SDL_AUDIO_ALLOW_CHANNELS_CHANGE) openDeviceChannels
                           ]
 
   channelsToWord8 Mono = 1


### PR DESCRIPTION
This is a simple bugfix. `foldChangeable` expects the value for `Mandate` as its first argument and the value for `Desire` as its second, but `changes` in `openAudioDevice` had them reversed, so this simply swaps the two values there.

I noticed this when trying to run `audio-example`. I use [JACK](https://jackaudio.org/) as my SDL audio driver; JACK expects samples as 32-bit floats. Under those circumstances, SDL will set the audio format to `AUDIO_F32` unless you insist otherwise. As written, `audio-example` was erroring out with "unsupported audio format" as a result of this, because `Mandate Signed16BitNativeAudio` was actually setting `SDL_AUDIO_ALLOW_FORMAT_CHANGE`. With this fix, `audio-example` runs properly in my environment.