### PR TITLE
Add binding for getWindowBordersSize

### DIFF
--- a/src/SDL/Raw/Video.hs
+++ b/src/SDL/Raw/Video.hs
@@ -37,6 +37,7 @@ module SDL.Raw.Video (
   getNumVideoDisplays,
   getNumVideoDrivers,
   getVideoDriver,
+  getWindowBordersSize,
   getWindowBrightness,
   getWindowData,
   getWindowDisplayIndex,
@@ -252,6 +253,7 @@ foreign import ccall "SDL.h SDL_GetNumDisplayModes" getNumDisplayModesFFI :: CIn
 foreign import ccall "SDL.h SDL_GetNumVideoDisplays" getNumVideoDisplaysFFI :: IO CInt
 foreign import ccall "SDL.h SDL_GetNumVideoDrivers" getNumVideoDriversFFI :: IO CInt
 foreign import ccall "SDL.h SDL_GetVideoDriver" getVideoDriverFFI :: CInt -> IO CString
+foreign import ccall "SDL.h SDL_GetWindowBordersSize" getWindowBordersSize :: Window -> Ptr CInt -> Ptr CInt -> Ptr CInt -> Ptr CInt -> IO CInt
 foreign import ccall "SDL.h SDL_GetWindowBrightness" getWindowBrightnessFFI :: Window -> IO CFloat
 foreign import ccall "SDL.h SDL_GetWindowData" getWindowDataFFI :: Window -> CString -> IO (Ptr ())
 foreign import ccall "SDL.h SDL_GetWindowDisplayIndex" getWindowDisplayIndexFFI :: Window -> IO CInt

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -32,6 +32,7 @@ module SDL.Video
   , windowGrab
   , setWindowMode
   , getWindowAbsolutePosition
+  , getWindowBordersSize
   , setWindowPosition
   , windowTitle
   , windowData
@@ -310,6 +311,21 @@ getWindowAbsolutePosition (Window w) =
     alloca $ \hPtr -> do
         Raw.getWindowPosition w wPtr hPtr
         V2 <$> peek wPtr <*> peek hPtr
+
+-- | Get the size of a window's borders (decorations) around the client area (top, left, bottom, right).
+--
+-- See @<https://wiki.libsdl.org/SDL_GetWindowBordersSize SDL_GetWindowBordersSize>@ for C documentation.
+getWindowBordersSize :: MonadIO m => Window -> m (Maybe (V4 CInt))
+getWindowBordersSize (Window win) =
+  liftIO $
+  alloca $ \tPtr ->
+  alloca $ \lPtr ->
+  alloca $ \bPtr ->
+  alloca $ \rPtr -> do
+    n <- Raw.getWindowBordersSize win tPtr lPtr bPtr rPtr
+    if n /= 0
+      then return Nothing
+      else fmap Just $ V4 <$> peek tPtr <*> peek lPtr <*> peek bPtr <*> peek rPtr
 
 -- | Get or set the size of a window's client area. Values beyond the maximum supported size are clamped.
 --


### PR DESCRIPTION
This change enables more accurate window position management
by taking into account the display server decoration.