### PR TITLE
AudioSpec now exports its constructor so you can access sample format

### DIFF
--- a/src/SDL/Audio.hs
+++ b/src/SDL/Audio.hs
@@ -54,13 +54,7 @@ module SDL.Audio
   , getAudioDeviceNames
 
     -- * 'AudioSpec'
-  , AudioSpec
-  , audioSpecFreq
-  , audioSpecFormat
-  , audioSpecChannels
-  , audioSpecSilence
-  , audioSpecSize
-  , audioSpecCallback
+  , AudioSpec(..)
 
     -- * Audio Drivers
   , getAudioDrivers


### PR DESCRIPTION
The main problem was the audioSpecFormat field has a hidden type variable
and the AudioSpec constructor was not exported. This means there was no
way to access the audioSpecFormat field. i.e.

  • Cannot use record selector ‘audioSpecFormat’ as a function due to escaped type variables
    Probable fix: use pattern-matching syntax instead
      (Which requires the constructor to be exported.)

At the same time, the audioSpecSamples field was not exported either.
Maybe there was a mix up.

Regardless, without the constructor and audioSpecFormat field we can't
pattern match to get the field. And nothing is wrong with the samples field.
So now all fields and the constructor for AudioSpec are exported from Audio.hs