### PR TITLE
Bump bounds for transformers dependency

### DIFF
--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -142,7 +142,7 @@ library
     exceptions >= 0.4 && < 0.11,
     StateVar >= 1.1.0.0 && < 1.3,
     text >= 1.1.0.0 && < 2.1,
-    transformers >= 0.2 && < 0.6,
+    transformers >= 0.2 && < 0.7,
     vector >= 0.10.9.0 && < 0.13
 
   if flag(no-linear)


### PR DESCRIPTION
Hackage hosts an incompatibly higher version now.