### PR TITLE
Add a flag allowing one to disable using pkgconfig

### DIFF
--- a/sdl2.cabal
+++ b/sdl2.cabal
@@ -61,6 +61,11 @@ flag recent-ish
   description:       Use features from a more recent libsdl2 release.
   default:           True
   manual:            False
+  
+flag pkgconfig
+  description:       Use pkgconfig to sort out SDL2 dependency
+  default:           True
+  manual:            True
 
 library
   -- ghc-options: -Wall -Werror
@@ -130,11 +135,13 @@ library
   if flag(recent-ish)
     cpp-options:
       -DRECENT_ISH
-    pkgconfig-depends:
-      sdl2 >= 2.0.10
+    if flag(pkgconfig)
+      pkgconfig-depends:
+        sdl2 >= 2.0.10
   else
-    pkgconfig-depends:
-      sdl2 >= 2.0.6
+    if flag(pkgconfig)
+      pkgconfig-depends:
+        sdl2 >= 2.0.6
 
   build-depends:
     base >= 4.7 && < 5,


### PR DESCRIPTION
Installing pkgconfig on Windows is a bit of a pain, and it's not totally necessary to getting the package running what with `extra-libraries` in there already. 

This is essentially a convenience for me when helping people set up `vulkan` on Windows, avoids "install chocolatey"/"install stack"/"download some decade old pkgconfiglite from sourceforge" kind of talk.