### PR TITLE
Change two field types from Int32 to JoystickID

### DIFF
--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -396,7 +396,7 @@ data JoyButtonEventData =
 data JoyDeviceEventData =
   JoyDeviceEventData {joyDeviceEventConnection :: !JoyDeviceConnection
                       -- ^ Was the device added or removed?
-                     ,joyDeviceEventWhich :: !Int32
+                     ,joyDeviceEventWhich :: !Raw.JoystickID
                       -- ^ The instance id of the joystick that reported the event.
                      }
   deriving (Eq,Ord,Generic,Show,Typeable)
@@ -427,7 +427,7 @@ data ControllerButtonEventData =
 data ControllerDeviceEventData =
   ControllerDeviceEventData {controllerDeviceEventConnection :: !ControllerDeviceConnection
                              -- ^ Was the device added, removed, or remapped?
-                            ,controllerDeviceEventWhich :: !Int32
+                            ,controllerDeviceEventWhich :: !Raw.JoystickID
                              -- ^ The joystick instance ID that reported the event.
                             }
   deriving (Eq,Ord,Generic,Show,Typeable)

--- a/src/SDL/Input/Joystick.hs
+++ b/src/SDL/Input/Joystick.hs
@@ -108,7 +108,7 @@ closeJoystick (Joystick j) = Raw.joystickClose j
 -- in future SDL events.
 --
 -- See @<https://wiki.libsdl.org/SDL_JoystickInstanceID SDL_JoystickInstanceID>@ for C documentation.
-getJoystickID :: MonadIO m => Joystick -> m (Int32)
+getJoystickID :: MonadIO m => Joystick -> m Raw.JoystickID
 getJoystickID (Joystick j) =
   throwIfNeg "SDL.Input.Joystick.getJoystickID" "SDL_JoystickInstanceID" $
   Raw.joystickInstanceID j


### PR DESCRIPTION
The comments indicate that these numbers are joystick IDs, so I'm guessing that it was an oversight not to use the `JoystickID` type alias for `Int32` here?