### PR TITLE
Enable compatibility with `base` < 4.11 (#310)

### DIFF
--- a/src/SDL/Input/Keyboard/Codes.hs
+++ b/src/SDL/Input/Keyboard/Codes.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
 
+#if MIN_VERSION_base(4,11,0)
 {-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+#endif
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 {-|

--- a/src/SDL/Input/Mouse.hs
+++ b/src/SDL/Input/Mouse.hs
@@ -68,6 +68,10 @@ import qualified SDL.Raw.Types as Raw
 import Control.Applicative
 #endif
 
+#if !MIN_VERSION_base(4,11,0)
+import Data.Monoid ((<>))
+#endif
+
 data LocationMode
   = AbsoluteLocation
   | RelativeLocation

--- a/src/SDL/Raw/Enum.hsc
+++ b/src/SDL/Raw/Enum.hsc
@@ -1,7 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE PatternSynonyms #-}
 
+#if MIN_VERSION_base(4,11,0)
 {-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+#endif
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 module SDL.Raw.Enum (


### PR DESCRIPTION
This commit enables compatibility of sdl2 with base versions prior to 4.11 (corresponding to GHC versions prior to 8.4). The patch requires introducing protections around a warning flag that didn't exist prior to GHC 8.4, and a conditional import.

This patch will help the `Yampa` and `dunai` projects use `sdl2`.