### PR TITLE
Fix links to https://wiki.libsdl.org/*

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ We need your help! The SDL API is fairly large, and the more hands we have, the
 quicker we can reach full coverage and release this to Hackage. There are a few
 ways you can help:
 
-1. Browse http://wiki.libsdl.org/CategoryAPI and find functions that aren't
+1. Browse https://wiki.libsdl.org/SDL2/CategoryAPI and find functions that aren't
    exposed in the high-level bindings.
 
 2. The above can be somewhat laborious - an easier way to find out what's
    missing is to write code.
 
-   * http://www.willusher.io/pages/sdl2/ is a collection of tutorials for C++.
-   * http://lazyfoo.net/tutorials/SDL/index.php is another collection of C++
+   * https://www.willusher.io/pages/sdl2/ is a collection of tutorials for C++.
+   * https://lazyfoo.net/tutorials/SDL/index.php is another collection of C++
      tutorials.
 
    Both of these would be useful if they were translated to Haskell, and we'd be

--- a/src/SDL/Audio.hs
+++ b/src/SDL/Audio.hs
@@ -140,7 +140,7 @@ data OpenDeviceSpec = forall sampleType. OpenDeviceSpec
 -- | Attempt to open the closest matching 'AudioDevice', as specified by the
 -- given 'OpenDeviceSpec'.
 --
--- See @<https://wiki.libsdl.org/SDL_OpenAudioDevice SDL_OpenAudioDevice>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_OpenAudioDevice SDL_OpenAudioDevice>@ for C documentation.
 openAudioDevice :: MonadIO m => OpenDeviceSpec -> m (AudioDevice, AudioSpec)
 openAudioDevice OpenDeviceSpec{..} = liftIO $
   maybeWith (BS.useAsCString . Text.encodeUtf8) openDeviceName $ \cDevName -> do
@@ -224,7 +224,7 @@ data Dict :: Constraint -> Type where
 
 -- |
 --
--- See @<https://wiki.libsdl.org/SDL_CloseAudioDevice SDL_CloseAudioDevice>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_CloseAudioDevice SDL_CloseAudioDevice>@ for C documentation.
 closeAudioDevice :: MonadIO m => AudioDevice -> m ()
 closeAudioDevice (AudioDevice d) = Raw.closeAudioDevice d
 

--- a/src/SDL/Event.hs
+++ b/src/SDL/Event.hs
@@ -889,7 +889,7 @@ registerEvent registeredEventDataToEvent eventToRegisteredEventData = do
 --
 -- 'pumpEvents' gathers all the pending input information from devices and places it in the event queue. Without calls to 'pumpEvents' no events would ever be placed on the queue. Often the need for calls to 'pumpEvents' is hidden from the user since 'pollEvent' and 'waitEvent' implicitly call 'pumpEvents'. However, if you are not polling or waiting for events (e.g. you are filtering them), then you must call 'pumpEvents' to force an event queue update.
 --
--- See @<https://wiki.libsdl.org/SDL_PumpEvents SDL_PumpEvents>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_PumpEvents SDL_PumpEvents>@ for C documentation.
 pumpEvents :: MonadIO m => m ()
 pumpEvents = Raw.pumpEvents
 
@@ -901,7 +901,7 @@ newtype EventWatch = EventWatch {runEventWatchRemoval :: IO ()}
 -- | Trigger an 'EventWatchCallback' when an event is added to the SDL
 -- event queue.
 --
--- See @<https://wiki.libsdl.org/SDL_AddEventWatch>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_AddEventWatch>@ for C documentation.
 addEventWatch :: MonadIO m => EventWatchCallback -> m EventWatch
 addEventWatch callback = liftIO $ do
   rawFilter <- Raw.mkEventFilter wrappedCb
@@ -918,7 +918,7 @@ addEventWatch callback = liftIO $ do
 
 -- | Remove an 'EventWatch'.
 --
--- See @<https://wiki.libsdl.org/SDL_DelEventWatch>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_DelEventWatch>@ for C documentation.
 delEventWatch :: MonadIO m => EventWatch -> m ()
 delEventWatch = liftIO . runEventWatchRemoval
 

--- a/src/SDL/Hint.hs
+++ b/src/SDL/Hint.hs
@@ -136,7 +136,7 @@ data VideoWinD3DCompilerOptions
   deriving (Bounded, Data, Enum, Eq, Generic, Ord, Read, Show, Typeable)
 
 -- | The 'Hint' type exports a well-typed interface to SDL's concept of
--- <https://wiki.libsdl.org/CategoryHints hints>. This type has instances for
+-- <https://wiki.libsdl.org/SDL2/CategoryHints hints>. This type has instances for
 -- both 'HasGetter' and 'HasSetter', allowing you to get and set hints. Note that
 -- the 'HasSetter' interface is fairly relaxed - if a hint cannot be set, the
 -- failure will be silently discarded. For more feedback and control when setting

--- a/src/SDL/Input/GameController.hs
+++ b/src/SDL/Input/GameController.hs
@@ -83,7 +83,7 @@ availableControllers = liftIO $ do
 
 {- | Open a controller so that you can start receiving events from interaction with this controller.
 
- See @<https://wiki.libsdl.org/SDL_GameControllerOpen SDL_GameControllerOpen>@ for C documentation.
+ See @<https://wiki.libsdl.org/SDL2/SDL_GameControllerOpen SDL_GameControllerOpen>@ for C documentation.
 -}
 openController
   :: (Functor m, MonadIO m)
@@ -97,14 +97,14 @@ openController (ControllerDevice _ x) =
 
 {- | Close a controller previously opened with 'openController'.
 
- See @<https://wiki.libsdl.org/SDL_GameControllerClose SDL_GameControllerClose>@ for C documentation.
+ See @<https://wiki.libsdl.org/SDL2/SDL_GameControllerClose SDL_GameControllerClose>@ for C documentation.
 -}
 closeController :: MonadIO m => GameController -> m ()
 closeController (GameController j) = Raw.gameControllerClose j
 
 {- | Check if a controller has been opened and is currently connected.
 
- See @<https://wiki.libsdl.org/SDL_GameControllerGetAttached SDL_GameControllerGetAttached>@ for C documentation.
+ See @<https://wiki.libsdl.org/SDL2/SDL_GameControllerGetAttached SDL_GameControllerGetAttached>@ for C documentation.
 -}
 controllerAttached :: MonadIO m => GameController -> m Bool
 controllerAttached (GameController c) = Raw.gameControllerGetAttached c
@@ -112,7 +112,7 @@ controllerAttached (GameController c) = Raw.gameControllerGetAttached c
 {- | Get the instance ID of an opened controller. The instance ID is used to identify the controller
  in future SDL events.
 
- See @<https://wiki.libsdl.org/SDL_GameControllerInstanceID SDL_GameControllerInstanceID>@ for C documentation.
+ See @<https://wiki.libsdl.org/SDL2/SDL_GameControllerInstanceID SDL_GameControllerInstanceID>@ for C documentation.
 -}
 getControllerID :: MonadIO m => GameController -> m Int32
 getControllerID (GameController c) =
@@ -121,7 +121,7 @@ getControllerID (GameController c) =
 
 {- | Get the current mapping of a Game Controller.
 
- See @<https://wiki.libsdl.org/SDL_GameControllerMapping SDL_GameControllerMapping>@ for C documentation.
+ See @<https://wiki.libsdl.org/SDL2/SDL_GameControllerMapping SDL_GameControllerMapping>@ for C documentation.
 -}
 controllerMapping :: MonadIO m => GameController -> m Text
 controllerMapping (GameController c) = liftIO $ do
@@ -133,7 +133,7 @@ controllerMapping (GameController c) = liftIO $ do
 {- | Add support for controllers that SDL is unaware of or to cause an existing controller to
  have a different binding.
 
- See @<https://wiki.libsdl.org/SDL_GameControllerAddMapping SDL_GameControllerAddMapping>@ for C documentation.
+ See @<https://wiki.libsdl.org/SDL2/SDL_GameControllerAddMapping SDL_GameControllerAddMapping>@ for C documentation.
 -}
 addControllerMapping :: MonadIO m => BS.ByteString -> m ()
 addControllerMapping mapping =
@@ -148,7 +148,7 @@ addControllerMapping mapping =
  @<https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt here>@
  (on GitHub).
 
- See @<https://wiki.libsdl.org/SDL_GameControllerAddMappingsFromFile SDL_GameControllerAddMappingsFromFile>@ for C documentation.
+ See @<https://wiki.libsdl.org/SDL2/SDL_GameControllerAddMappingsFromFile SDL_GameControllerAddMappingsFromFile>@ for C documentation.
 -}
 addControllerMappingsFromFile :: MonadIO m => FilePath -> m ()
 addControllerMappingsFromFile mappingFile =
@@ -158,7 +158,7 @@ addControllerMappingsFromFile mappingFile =
 
 {- | Get the current state of an axis control on a game controller.
 
- See @<https://wiki.libsdl.org/SDL_GameControllerGetAxis SDL_GameControllerGetAxis>@ for C documentation.
+ See @<https://wiki.libsdl.org/SDL2/SDL_GameControllerGetAxis SDL_GameControllerGetAxis>@ for C documentation.
 -}
 controllerAxis :: MonadIO m => GameController -> ControllerAxis -> m Int16
 controllerAxis (GameController c) axis =
@@ -166,7 +166,7 @@ controllerAxis (GameController c) axis =
 
 {- | Get the current state of a button on a game controller.
 
- See @<https://wiki.libsdl.org/SDL_GameControllerGetButton SDL_GameControllerGetButton>@ for C documentation.
+ See @<https://wiki.libsdl.org/SDL2/SDL_GameControllerGetButton SDL_GameControllerGetButton>@ for C documentation.
 -}
 controllerButton :: MonadIO m => GameController -> ControllerButton -> m ControllerButtonState
 controllerButton (GameController c) button =

--- a/src/SDL/Input/Joystick.hs
+++ b/src/SDL/Input/Joystick.hs
@@ -71,7 +71,7 @@ instance FromNumber JoyButtonState Word8 where
 
 -- | Count the number of joysticks attached to the system.
 --
--- See @<https://wiki.libsdl.org/SDL_NumJoysticks SDL_NumJoysticks>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_NumJoysticks SDL_NumJoysticks>@ for C documentation.
 numJoysticks :: MonadIO m => m (CInt)
 numJoysticks = throwIfNeg "SDL.Input.Joystick.availableJoysticks" "SDL_NumJoysticks" Raw.numJoysticks
 
@@ -89,7 +89,7 @@ availableJoysticks = liftIO $ do
 
 -- | Open a joystick so that you can start receiving events from interaction with this joystick.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickOpen SDL_JoystickOpen>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickOpen SDL_JoystickOpen>@ for C documentation.
 openJoystick :: (Functor m,MonadIO m)
              => JoystickDevice -- ^ The device to open. Use 'availableJoysticks' to find 'JoystickDevices's
              -> m Joystick
@@ -100,14 +100,14 @@ openJoystick (JoystickDevice _ x) =
 
 -- | Close a joystick previously opened with 'openJoystick'.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickClose SDL_JoystickClose>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickClose SDL_JoystickClose>@ for C documentation.
 closeJoystick :: MonadIO m => Joystick -> m ()
 closeJoystick (Joystick j) = Raw.joystickClose j
 
 -- | Get the instance ID of an opened joystick. The instance ID is used to identify the joystick
 -- in future SDL events.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickInstanceID SDL_JoystickInstanceID>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickInstanceID SDL_JoystickInstanceID>@ for C documentation.
 getJoystickID :: MonadIO m => Joystick -> m Raw.JoystickID
 getJoystickID (Joystick j) =
   throwIfNeg "SDL.Input.Joystick.getJoystickID" "SDL_JoystickInstanceID" $
@@ -115,7 +115,7 @@ getJoystickID (Joystick j) =
 
 -- | Determine if a given button is currently held.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickGetButton SDL_JoystickGetButton>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickGetButton SDL_JoystickGetButton>@ for C documentation.
 buttonPressed :: (Functor m, MonadIO m)
               => Joystick
               -> CInt -- ^ The index of the button. You can use 'numButtons' to determine how many buttons a given joystick has.
@@ -124,7 +124,7 @@ buttonPressed (Joystick j) buttonIndex = (== 1) <$> Raw.joystickGetButton j butt
 
 -- | Get the ball axis change since the last poll.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickGetBall SDL_JoystickGetBall>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickGetBall SDL_JoystickGetBall>@ for C documentation.
 ballDelta :: MonadIO m
           => Joystick
           -> CInt -- ^ The index of the joystick ball. You can use 'numBalls' to determine how many balls a given joystick has.
@@ -145,25 +145,25 @@ ballDelta (Joystick j) ballIndex = liftIO $
 --
 -- Some joysticks use axes 2 and 3 for extra buttons.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickGetAxis SDL_JoystickGetAxis>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickGetAxis SDL_JoystickGetAxis>@ for C documentation.
 axisPosition :: MonadIO m => Joystick -> CInt -> m Int16
 axisPosition (Joystick j) axisIndex = Raw.joystickGetAxis j axisIndex
 
 -- | Get the number of general axis controls on a joystick.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickNumAxes SDL_JoystickNumAxes>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickNumAxes SDL_JoystickNumAxes>@ for C documentation.
 numAxes :: (MonadIO m) => Joystick -> m CInt
 numAxes (Joystick j) = liftIO $ throwIfNeg "SDL.Input.Joystick.numAxis" "SDL_JoystickNumAxes" (Raw.joystickNumAxes j)
 
 -- | Get the number of buttons on a joystick.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickNumButtons SDL_JoystickNumButtons>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickNumButtons SDL_JoystickNumButtons>@ for C documentation.
 numButtons :: (MonadIO m) => Joystick -> m CInt
 numButtons (Joystick j) = liftIO $ throwIfNeg "SDL.Input.Joystick.numButtons" "SDL_JoystickNumButtons" (Raw.joystickNumButtons j)
 
 -- | Get the number of trackballs on a joystick.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickNumBalls SDL_JoystickNumBalls>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickNumBalls SDL_JoystickNumBalls>@ for C documentation.
 numBalls :: (MonadIO m) => Joystick -> m CInt
 numBalls (Joystick j) = liftIO $ throwIfNeg "SDL.Input.Joystick.numBalls" "SDL_JoystickNumBalls" (Raw.joystickNumBalls j)
 
@@ -195,7 +195,7 @@ instance FromNumber JoyHatPosition Word8 where
 
 -- | Get current position of a POV hat on a joystick.
 --
--- See @<https://wiki.libsdl.org/SDL_JoystickGetHat SDL_JoystickGetHat>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickGetHat SDL_JoystickGetHat>@ for C documentation.
 getHat :: (Functor m, MonadIO m)
        => Joystick
        -> CInt -- ^ The index of the POV hat. You can use 'numHats' to determine how many POV hats a given joystick has.
@@ -204,7 +204,7 @@ getHat (Joystick j) hatIndex = fromNumber <$> Raw.joystickGetHat j hatIndex
 
 -- | Get the number of POV hats on a joystick.
 --
--- See @<https://wiki.libsdl.org/https://wiki.libsdl.org/SDL_JoystickNumHats SDL_JoystickNumHats>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_JoystickNumHats SDL_JoystickNumHats>@ for C documentation.
 numHats :: (MonadIO m) => Joystick -> m CInt
 numHats (Joystick j) = liftIO $ throwIfNeg "SDL.Input.Joystick.numHats" "SDL_JoystickNumHats" (Raw.joystickNumHats j)
 

--- a/src/SDL/Input/Keyboard.hs
+++ b/src/SDL/Input/Keyboard.hs
@@ -56,7 +56,7 @@ import Control.Applicative
 
 -- | Get the current key modifier state for the keyboard. The key modifier state is a mask special keys that are held down.
 --
--- See @<https://wiki.libsdl.org/SDL_GetModState SDL_GetModState>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetModState SDL_GetModState>@ for C documentation.
 getModState :: (Functor m, MonadIO m) => m KeyModifier
 getModState = fromNumber <$> Raw.getModState
 
@@ -108,7 +108,7 @@ instance ToNumber KeyModifier Word32 where
 -- | Set the rectangle used to type text inputs and start accepting text input
 -- events.
 --
--- See @<https://wiki.libsdl.org/SDL_StartTextInput SDL_StartTextInput>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_StartTextInput SDL_StartTextInput>@ for C documentation.
 startTextInput :: MonadIO m => Raw.Rect -> m ()
 startTextInput rect = liftIO $ do
   alloca $ \ptr -> do
@@ -118,25 +118,25 @@ startTextInput rect = liftIO $ do
 
 -- | Stop receiving any text input events.
 --
--- See @<https://wiki.libsdl.org/SDL_StopTextInput SDL_StopTextInput>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_StopTextInput SDL_StopTextInput>@ for C documentation.
 stopTextInput :: MonadIO m => m ()
 stopTextInput = Raw.stopTextInput
 
 -- | Check whether the platform has screen keyboard support.
 --
--- See @<https://wiki.libsdl.org/SDL_HasScreenKeyboardSupport SDL_HasScreenKeyboardSupport>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_HasScreenKeyboardSupport SDL_HasScreenKeyboardSupport>@ for C documentation.
 hasScreenKeyboardSupport :: MonadIO m => m Bool
 hasScreenKeyboardSupport = Raw.hasScreenKeyboardSupport
 
 -- | Check whether the screen keyboard is shown for the given window.
 --
--- See @<https://wiki.libsdl.org/SDL_IsScreenKeyboardShown SDL_IsScreenKeyboardShown>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_IsScreenKeyboardShown SDL_IsScreenKeyboardShown>@ for C documentation.
 isScreenKeyboardShown :: MonadIO m => Window -> m Bool
 isScreenKeyboardShown (Window w) = Raw.isScreenKeyboardShown w
 
 -- | Get a human-readable name for a scancode. If the scancode doesn't have a name this function returns the empty string.
 --
--- See @<https://wiki.libsdl.org/SDL_GetScancodeName SDL_GetScancodeName>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetScancodeName SDL_GetScancodeName>@ for C documentation.
 getScancodeName :: MonadIO m => Scancode -> m String
 getScancodeName scancode = liftIO $ do
   name <- Raw.getScancodeName $ toNumber scancode
@@ -156,7 +156,7 @@ data Keysym = Keysym
 --
 -- This computation generates a mapping from 'Scancode' to 'Bool' - evaluating the function at specific 'Scancode's will inform you as to whether or not that key was held down when 'getKeyboardState' was called.
 --
--- See @<https://wiki.libsdl.org/SDL_GetKeyboardState SDL_GetKeyboardState>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetKeyboardState SDL_GetKeyboardState>@ for C documentation.
 getKeyboardState :: MonadIO m => m (Scancode -> Bool)
 getKeyboardState = liftIO $ do
   alloca $ \nkeys -> do

--- a/src/SDL/Input/Mouse.hs
+++ b/src/SDL/Input/Mouse.hs
@@ -177,7 +177,7 @@ warpMouse WarpGlobal (P (V2 x y)) = throwIfNeg_ "SDL.Mouse.warpMouse" "SDL_WarpM
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_ShowCursor SDL_ShowCursor>@ and @<https://wiki.libsdl.org/SDL_HideCursor SDL_HideCursor>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_ShowCursor SDL_ShowCursor>@ and @<https://wiki.libsdl.org/SDL2/SDL_HideCursor SDL_HideCursor>@ for C documentation.
 cursorVisible :: StateVar Bool
 cursorVisible = makeStateVar getCursorVisible setCursorVisible
   where
@@ -249,7 +249,7 @@ instance ToNumber SystemCursor Word32 where
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetCursor SDL_SetCursor>@ and @<https://wiki.libsdl.org/SDL_GetCursor SDL_GetCursor>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetCursor SDL_SetCursor>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetCursor SDL_GetCursor>@ for C documentation.
 activeCursor :: StateVar Cursor
 activeCursor = makeStateVar getCursor setCursor
   where
@@ -345,13 +345,13 @@ createCursorFrom point source = do
 
 -- | Free a cursor created with 'createCursor', 'createColorCusor' and 'createSystemCursor'.
 --
--- See @<https://wiki.libsdl.org/SDL_FreeCursor SDL_FreeCursor>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_FreeCursor SDL_FreeCursor>@ for C documentation.
 freeCursor :: MonadIO m => Cursor -> m ()
 freeCursor = Raw.freeCursor . unwrapCursor
 
 -- | Create a color cursor.
 --
--- See @<https://wiki.libsdl.org/SDL_CreateColorCursor SDL_CreateColorCursor>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_CreateColorCursor SDL_CreateColorCursor>@ for C documentation.
 createColorCursor :: MonadIO m
                   => Surface
                   -> Point V2 CInt -- ^ The location of the cursor hot spot
@@ -363,7 +363,7 @@ createColorCursor (Surface surfPtr _) (P (V2 hx hy)) =
 
 -- | Create system cursor.
 --
--- See @<https://wiki.libsdl.org/SDL_CreateSystemCursor SDL_CreateSystemCursor>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_CreateSystemCursor SDL_CreateSystemCursor>@ for C documentation.
 createSystemCursor :: MonadIO m => SystemCursor -> m Cursor
 createSystemCursor sc =
     liftIO . fmap Cursor $

--- a/src/SDL/Power.hs
+++ b/src/SDL/Power.hs
@@ -27,7 +27,7 @@ import qualified SDL.Raw as Raw
 --
 -- Throws 'SDLException' if the current power state can not be determined.
 --
--- See @<https://wiki.libsdl.org/SDL_GetPowerInfo SDL_GetPowerInfo>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetPowerInfo SDL_GetPowerInfo>@ for C documentation.
 getPowerInfo :: (Functor m, MonadIO m) => m PowerState
 getPowerInfo =
   liftIO $

--- a/src/SDL/Time.hs
+++ b/src/SDL/Time.hs
@@ -35,13 +35,13 @@ import qualified SDL.Raw.Types as Raw
 
 -- | Number of milliseconds since library initialization.
 --
--- See @<https://wiki.libsdl.org/SDL_GetTicks SDL_GetTicks>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetTicks SDL_GetTicks>@ for C documentation.
 ticks :: MonadIO m => m Word32
 ticks = Raw.getTicks
 
 -- | The current time in seconds since some arbitrary starting point (consist over the life of the application).
 --
--- This time is derived from the system's performance counter - see @<https://wiki.libsdl.org/SDL_GetPerformanceFrequency SDL_GetPerformanceFrequency>@ and @<https://wiki.libsdl.org/SDL_GetPerformanceCounter SDL_GetPerformanceCounter>@ for C documentation about the implementation.
+-- This time is derived from the system's performance counter - see @<https://wiki.libsdl.org/SDL2/SDL_GetPerformanceFrequency SDL_GetPerformanceFrequency>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetPerformanceCounter SDL_GetPerformanceCounter>@ for C documentation about the implementation.
 time :: (Fractional a, MonadIO m) => m a
 time = do
   freq <- Raw.getPerformanceFrequency
@@ -52,7 +52,7 @@ time = do
 --
 -- Users are generally recommended to use 'threadDelay' instead, to take advantage of the abilities of the Haskell runtime.
 --
--- See @<https://wiki.libsdl.org/SDL_Delay SDL_Delay>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_Delay SDL_Delay>@ for C documentation.
 delay :: MonadIO m => Word32 -> m ()
 delay = Raw.delay
 
@@ -73,7 +73,7 @@ newtype Timer =
 
 -- | Set up a callback function to be run on a separate thread after the specified number of milliseconds has elapsed.
 --
--- See @<https://wiki.libsdl.org/SDL_AddTimer SDL_AddTimer>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_AddTimer SDL_AddTimer>@ for C documentation.
 addTimer :: MonadIO m => Word32 -> TimerCallback -> m Timer
 addTimer timeout callback = liftIO $ do
     cb <- Raw.mkTimerCallback wrappedCb
@@ -96,14 +96,14 @@ addTimer timeout callback = liftIO $ do
 
 -- | Remove a 'Timer'.
 --
--- See @<https://wiki.libsdl.org/SDL_RemoveTimer SDL_RemoveTimer>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RemoveTimer SDL_RemoveTimer>@ for C documentation.
 removeTimer :: MonadIO m => Timer -> m Bool
 removeTimer f = liftIO $ runTimerRemoval f
 
 #ifdef RECENT_ISH
 -- | Number of milliseconds since library initialization.
 --
--- See @<https://wiki.libsdl.org/SDL_GetTicks64 SDL_GetTicks64>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetTicks64 SDL_GetTicks64>@ for C documentation.
 ticks64 :: MonadIO m => m Word64
 ticks64 = Raw.getTicks64
 #endif

--- a/src/SDL/Video.hs
+++ b/src/SDL/Video.hs
@@ -321,7 +321,7 @@ getWindowAbsolutePosition (Window w) =
 
 -- | Get the size of a window's borders (decorations) around the client area (top, left, bottom, right).
 --
--- See @<https://wiki.libsdl.org/SDL_GetWindowBordersSize SDL_GetWindowBordersSize>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetWindowBordersSize SDL_GetWindowBordersSize>@ for C documentation.
 getWindowBordersSize :: MonadIO m => Window -> m (Maybe (V4 CInt))
 getWindowBordersSize (Window win) =
   liftIO $
@@ -341,7 +341,7 @@ getWindowBordersSize (Window win) =
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetWindowSize SDL_SetWindowSize>@ and @<https://wiki.libsdl.org/SDL_GetWindowSize SDL_GetWindowSize>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetWindowSize SDL_SetWindowSize>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetWindowSize SDL_GetWindowSize>@ for C documentation.
 windowSize :: Window -> StateVar (V2 CInt)
 windowSize (Window win) = makeStateVar getWindowSize setWindowSize
   where
@@ -358,7 +358,7 @@ windowSize (Window win) = makeStateVar getWindowSize setWindowSize
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetWindowTitle SDL_SetWindowTitle>@ and @<https://wiki.libsdl.org/SDL_GetWindowTitle SDL_GetWindowTitle>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetWindowTitle SDL_SetWindowTitle>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetWindowTitle SDL_GetWindowTitle>@ for C documentation.
 windowTitle :: Window -> StateVar Text
 windowTitle (Window w) = makeStateVar getWindowTitle setWindowTitle
   where
@@ -432,13 +432,13 @@ setClipboardText str = liftIO $ do
 
 -- | Hide a window.
 --
--- See @<https://wiki.libsdl.org/SDL_HideWindow SDL_HideWindow>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_HideWindow SDL_HideWindow>@ for C documentation.
 hideWindow :: MonadIO m => Window -> m ()
 hideWindow (Window w) = Raw.hideWindow w
 
 -- | Raise the window above other windows and set the input focus.
 --
--- See @<https://wiki.libsdl.org/SDL_RaiseWindow SDL_RaiseWindow>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RaiseWindow SDL_RaiseWindow>@ for C documentation.
 raiseWindow :: MonadIO m => Window -> m ()
 raiseWindow (Window w) = Raw.raiseWindow w
 
@@ -455,7 +455,7 @@ screenSaverEnabled = makeStateVar (isScreenSaverEnabled) (setScreenSaverEnabled)
 
 -- | Show a window.
 --
--- See @<https://wiki.libsdl.org/SDL_ShowWindow SDL_ShowWindow>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_ShowWindow SDL_ShowWindow>@ for C documentation.
 showWindow :: MonadIO m => Window -> m ()
 showWindow (Window w) = Raw.showWindow w
 
@@ -582,7 +582,7 @@ instance ToNumber MessageKind Word32 where
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetWindowMaximumSize SDL_SetWindowMaximumSize>@ and @<https://wiki.libsdl.org/SDL_GetWindowMaximumSize SDL_GetWindowMaximumSize>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetWindowMaximumSize SDL_SetWindowMaximumSize>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetWindowMaximumSize SDL_GetWindowMaximumSize>@ for C documentation.
 windowMaximumSize :: Window -> StateVar (V2 CInt)
 windowMaximumSize (Window win) = makeStateVar getWindowMaximumSize setWindowMaximumSize
   where
@@ -599,7 +599,7 @@ windowMaximumSize (Window win) = makeStateVar getWindowMaximumSize setWindowMaxi
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetWindowMinimumSize SDL_SetWindowMinimumSize>@ and @<https://wiki.libsdl.org/SDL_GetWindowMinimumSize SDL_GetWindowMinimumSize>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetWindowMinimumSize SDL_SetWindowMinimumSize>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetWindowMinimumSize SDL_GetWindowMinimumSize>@ for C documentation.
 windowMinimumSize :: Window -> StateVar (V2 CInt)
 windowMinimumSize (Window win) = makeStateVar getWindowMinimumSize setWindowMinimumSize
   where
@@ -616,7 +616,7 @@ windowMinimumSize (Window win) = makeStateVar getWindowMinimumSize setWindowMini
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetWindowOpacity SDL_SetWindowOpacity>@ and @<https://wiki.libsdl.org/SDL_GetWindowOpacity SDL_GetWindowOpacity>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetWindowOpacity SDL_SetWindowOpacity>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetWindowOpacity SDL_GetWindowOpacity>@ for C documentation.
 windowOpacity :: Window -> StateVar CFloat
 windowOpacity (Window win) = makeStateVar getWindowOpacity setWindowOpacity
   where
@@ -636,7 +636,7 @@ createRenderer (Window w) driver config =
 
 -- | Create a 2D software rendering context for the given surface.
 --
--- See @<https://wiki.libsdl.org/SDL_CreateSoftwareRenderer>@
+-- See @<https://wiki.libsdl.org/SDL2/SDL_CreateSoftwareRenderer>@
 createSoftwareRenderer :: MonadIO m => Surface -> m Renderer
 createSoftwareRenderer (Surface ptr _) =
   liftIO . fmap Renderer $

--- a/src/SDL/Video/OpenGL.hs
+++ b/src/SDL/Video/OpenGL.hs
@@ -103,7 +103,7 @@ newtype GLContext = GLContext Raw.GLContext
 -- Throws 'SDLException' if the window wasn't configured with OpenGL
 -- support, or if context creation fails.
 --
--- See @<https://wiki.libsdl.org/SDL_GL_CreateContext SDL_GL_CreateContext>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GL_CreateContext SDL_GL_CreateContext>@ for C documentation.
 glCreateContext :: (Functor m, MonadIO m) => Window -> m GLContext
 glCreateContext (Window w) =
   GLContext <$> throwIfNull "SDL.Video.glCreateContext" "SDL_GL_CreateContext"
@@ -113,7 +113,7 @@ glCreateContext (Window w) =
 --
 -- Throws 'SDLException' on failure.
 --
--- See @<https://wiki.libsdl.org/SDL_GL_MakeCurrent SDL_GL_MakeCurrent>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GL_MakeCurrent SDL_GL_MakeCurrent>@ for C documentation.
 glMakeCurrent :: (Functor m, MonadIO m) => Window -> GLContext -> m ()
 glMakeCurrent (Window w) (GLContext ctx) =
   throwIfNeg_ "SDL.Video.OpenGL.glMakeCurrent" "SDL_GL_MakeCurrent" $
@@ -128,7 +128,7 @@ glMakeCurrent (Window w) (GLContext ctx) =
 -- The @glFinish@ command will block until the command queue has been fully
 -- processed. You should call that function before deleting a context.
 --
--- See @<https://wiki.libsdl.org/SDL_GL_DeleteContext SDL_GL_DeleteContext>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GL_DeleteContext SDL_GL_DeleteContext>@ for C documentation.
 glDeleteContext :: MonadIO m => GLContext -> m ()
 glDeleteContext (GLContext ctx) = Raw.glDeleteContext ctx
 
@@ -136,7 +136,7 @@ glDeleteContext (GLContext ctx) = Raw.glDeleteContext ctx
 -- contents of the back buffer are undefined, clear them with @glClear@ or
 -- equivalent before drawing to them again.
 --
--- See @<https://wiki.libsdl.org/SDL_GL_SwapWindow SDL_GL_SwapWindow>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GL_SwapWindow SDL_GL_SwapWindow>@ for C documentation.
 glSwapWindow :: MonadIO m => Window -> m ()
 glSwapWindow (Window w) = Raw.glSwapWindow w
 
@@ -167,7 +167,7 @@ instance FromNumber SwapInterval CInt where
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_GL_SetSwapInterval SDL_GL_SetSwapInterval>@ and @<https://wiki.libsdl.org/SDL_GL_GetSwapInterval SDL_GL_GetSwapInterval>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GL_SetSwapInterval SDL_GL_SetSwapInterval>@ and @<https://wiki.libsdl.org/SDL2/SDL_GL_GetSwapInterval SDL_GL_GetSwapInterval>@ for C documentation.
 swapInterval :: StateVar SwapInterval
 swapInterval = makeStateVar glGetSwapInterval glSetSwapInterval
   where

--- a/src/SDL/Video/Renderer.hs
+++ b/src/SDL/Video/Renderer.hs
@@ -170,7 +170,7 @@ import Data.Traversable
 
 -- | Perform a fast surface copy to a destination surface.
 --
--- See @<https://wiki.libsdl.org/SDL_BlitSurface SDL_BlitSurface>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_BlitSurface SDL_BlitSurface>@ for C documentation.
 surfaceBlit :: MonadIO m
             => Surface -- ^ The 'Surface' to be copied from
             -> Maybe (Rectangle CInt) -- ^ The rectangle to be copied, or 'Nothing' to copy the entire surface
@@ -186,7 +186,7 @@ surfaceBlit (Surface src _) srcRect (Surface dst _) dstLoc = liftIO $
 
 -- | Create a texture for a rendering context.
 --
--- See @<https://wiki.libsdl.org/SDL_CreateTexture SDL_CreateTexture>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_CreateTexture SDL_CreateTexture>@ for C documentation.
 createTexture :: (Functor m,MonadIO m)
               => Renderer -- ^ The rendering context.
               -> PixelFormat
@@ -200,7 +200,7 @@ createTexture (Renderer r) fmt access (V2 w h) =
 
 -- | Create a texture from an existing surface.
 --
--- See @<https://wiki.libsdl.org/SDL_CreateTextureFromSurface SDL_CreateTextureFromSurface>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_CreateTextureFromSurface SDL_CreateTextureFromSurface>@ for C documentation.
 createTextureFromSurface :: (Functor m,MonadIO m)
                          => Renderer -- ^ The rendering context
                          -> Surface -- ^ The surface containing pixel data used to fill the texture
@@ -212,7 +212,7 @@ createTextureFromSurface (Renderer r) (Surface s _) =
 
 -- | Bind an OpenGL\/ES\/ES2 texture to the current context for use with when rendering OpenGL primitives directly.
 --
--- See @<https://wiki.libsdl.org/SDL_GL_BindTexture SDL_GL_BindTexture>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GL_BindTexture SDL_GL_BindTexture>@ for C documentation.
 glBindTexture :: (Functor m,MonadIO m)
               => Texture -- ^ The texture to bind to the current OpenGL\/ES\/ES2 context
               -> m ()
@@ -222,7 +222,7 @@ glBindTexture (Texture t) =
 
 -- | Unbind an OpenGL\/ES\/ES2 texture from the current context.
 --
--- See @<https://wiki.libsdl.org/SDL_GL_UnbindTexture SDL_GL_UnbindTexture>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GL_UnbindTexture SDL_GL_UnbindTexture>@ for C documentation.
 glUnbindTexture :: (Functor m,MonadIO m)
                 => Texture -- ^ The texture to unbind from the current OpenGL\/ES\/ES2 context
                 -> m ()
@@ -232,7 +232,7 @@ glUnbindTexture (Texture t) =
 
 -- | Updates texture rectangle with new pixel data.
 --
--- See @<https://wiki.libsdl.org/SDL_UpdateTexture SDL_UpdateTexture>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_UpdateTexture SDL_UpdateTexture>@ for C documentation.
 updateTexture :: (Functor m, MonadIO m)
               => Texture -- ^ The 'Texture' to be updated
               -> Maybe (Rectangle CInt) -- ^ The area to update, Nothing for entire texture
@@ -248,13 +248,13 @@ updateTexture (Texture t) rect pixels pitch = do
 
 -- | Destroy the specified texture.
 --
--- See @<https://wiki.libsdl.org/SDL_DestroyTexture SDL_DestroyTexture>@ for the C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_DestroyTexture SDL_DestroyTexture>@ for the C documentation.
 destroyTexture :: MonadIO m => Texture -> m ()
 destroyTexture (Texture t) = Raw.destroyTexture t
 
 -- | Lock a portion of the texture for *write-only* pixel access.
 --
--- See @<https://wiki.libsdl.org/SDL_LockTexture SDL_LockTexture>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_LockTexture SDL_LockTexture>@ for C documentation.
 lockTexture :: MonadIO m
             => Texture -- ^ The 'Texture' to lock for access, which must have been created with 'TextureAccessStreaming'
             -> Maybe (Rectangle CInt) -- ^ The area to lock for access; 'Nothing' to lock the entire texture
@@ -273,13 +273,13 @@ lockTexture (Texture t) rect = liftIO $
 --
 -- /Warning/: See <https://bugzilla.libsdl.org/show_bug.cgi?id=1586 Bug No. 1586> before using this function!
 --
--- See @<https://wiki.libsdl.org/SDL_UnlockTexture SDL_UnlockTexture>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_UnlockTexture SDL_UnlockTexture>@ for C documentation.
 unlockTexture :: MonadIO m => Texture -> m ()
 unlockTexture (Texture t) = Raw.unlockTexture t
 
 -- | Set up a surface for directly accessing the pixels.
 --
--- See @<https://wiki.libsdl.org/SDL_LockSurface SDL_LockSurface>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_LockSurface SDL_LockSurface>@ for C documentation.
 lockSurface :: MonadIO m => Surface -> m ()
 lockSurface (Surface s _) =
   throwIfNeg_ "lockSurface" "SDL_LockSurface" $
@@ -287,7 +287,7 @@ lockSurface (Surface s _) =
 
 -- | Release a surface after directly accessing the pixels.
 --
--- See @<https://wiki.libsdl.org/SDL_UnlockSurface SDL_UnlockSurface>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_UnlockSurface SDL_UnlockSurface>@ for C documentation.
 unlockSurface :: MonadIO m => Surface -> m ()
 unlockSurface (Surface s _) = Raw.unlockSurface s
 
@@ -327,7 +327,7 @@ data TextureInfo = TextureInfo
 
 -- | Query the attributes of a texture.
 --
--- See @<https://wiki.libsdl.org/SDL_QueryTexture SDL_QueryTexture>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_QueryTexture SDL_QueryTexture>@ for C documentation.
 queryTexture :: MonadIO m => Texture -> m TextureInfo
 queryTexture (Texture tex) = liftIO $
   alloca $ \pfPtr ->
@@ -344,7 +344,7 @@ queryTexture (Texture tex) = liftIO $
 
 -- | Allocate a new RGB surface.
 --
--- See @<https://wiki.libsdl.org/SDL_CreateRGBSurface SDL_CreateRGBSurface>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_CreateRGBSurface SDL_CreateRGBSurface>@ for C documentation.
 createRGBSurface :: (Functor m, MonadIO m)
                  => V2 CInt -- ^ The size of the surface
                  -> PixelFormat -- ^ The bit depth, red, green, blue and alpha mask for the pixels
@@ -357,7 +357,7 @@ createRGBSurface (V2 w h) pf =
 
 -- | Allocate a new RGB surface with existing pixel data.
 --
--- See @<https://wiki.libsdl.org/SDL_CreateRGBSurfaceFrom SDL_CreateRGBSurfaceFrom>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_CreateRGBSurfaceFrom SDL_CreateRGBSurfaceFrom>@ for C documentation.
 createRGBSurfaceFrom :: (Functor m, MonadIO m)
                      => MSV.IOVector Word8 -- ^ The existing pixel data
                      -> V2 CInt -- ^ The size of the surface
@@ -375,7 +375,7 @@ createRGBSurfaceFrom pixels (V2 w h) p pf = liftIO $
 --
 -- If there is a clip rectangle set on the destination (set via 'clipRect'), then this function will fill based on the intersection of the clip rectangle and the given 'Rectangle'.
 --
--- See @<https://wiki.libsdl.org/SDL_FillRect SDL_FillRect>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_FillRect SDL_FillRect>@ for C documentation.
 surfaceFillRect :: MonadIO m
                 => Surface -- ^ The 'Surface' that is the drawing target.
                 -> Maybe (Rectangle CInt) -- ^ The rectangle to fill, or 'Nothing' to fill the entire surface.
@@ -391,7 +391,7 @@ surfaceFillRect (Surface s _) rect (V4 r g b a) = liftIO $
 --
 -- If there is a clip rectangle set on any of the destinations (set via 'clipRect'), then this function will fill based on the intersection of the clip rectangle and the given 'Rectangle's.
 --
--- See @<https://wiki.libsdl.org/SDL_FillRect SDL_FillRects>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_FillRect SDL_FillRects>@ for C documentation.
 surfaceFillRects :: MonadIO m
                  => Surface -- ^ The 'Surface' that is the drawing target.
                  -> SV.Vector (Rectangle CInt) -- ^ A 'SV.Vector' of 'Rectangle's to be filled.
@@ -410,13 +410,13 @@ surfaceFillRects (Surface s _) rects (V4 r g b a) = liftIO $ do
 --
 -- If the surface was created using 'createRGBSurfaceFrom' then the pixel data is not freed.
 --
--- See @<https://wiki.libsdl.org/SDL_FreeSurface SDL_FreeSurface>@ for the C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_FreeSurface SDL_FreeSurface>@ for the C documentation.
 freeSurface :: MonadIO m => Surface -> m ()
 freeSurface (Surface s _) = Raw.freeSurface s
 
 -- | Load a surface from a BMP file.
 --
--- See @<https://wiki.libsdl.org/SDL_LoadBMP SDL_LoadBMP>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_LoadBMP SDL_LoadBMP>@ for C documentation.
 loadBMP :: MonadIO m => FilePath -> m Surface
 loadBMP filePath = liftIO $
   fmap unmanagedSurface $
@@ -477,7 +477,7 @@ paletteColor q@(Palette p) i = do
 
 -- | Set a range of colors in a palette.
 --
--- See @<https://wiki.libsdl.org/SDL_SetPaletteColors SDL_SetPaletteColors>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetPaletteColors SDL_SetPaletteColors>@ for C documentation.
 setPaletteColors :: MonadIO m
                  => Palette -- ^ The 'Palette' to modify
                  -> (SV.Vector (V4 Word8)) -- ^ A 'SV.Vector' of colours to copy into the palette
@@ -492,7 +492,7 @@ setPaletteColors (Palette p) colors first = liftIO $
 
 -- | Get the SDL surface associated with the window.
 --
--- See @<https://wiki.libsdl.org/SDL_GetWindowSurface SDL_GetWindowSurface>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetWindowSurface SDL_GetWindowSurface>@ for C documentation.
 getWindowSurface :: (Functor m, MonadIO m) => Window -> m Surface
 getWindowSurface (Window w) =
   fmap unmanagedSurface $
@@ -503,7 +503,7 @@ getWindowSurface (Window w) =
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetRenderDrawBlendMode SDL_SetRenderDrawBlendMode>@ and @<https://wiki.libsdl.org/SDL_GetRenderDrawBlendMode SDL_GetRenderDrawBlendMode>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetRenderDrawBlendMode SDL_SetRenderDrawBlendMode>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetRenderDrawBlendMode SDL_GetRenderDrawBlendMode>@ for C documentation.
 rendererDrawBlendMode :: Renderer -> StateVar BlendMode
 rendererDrawBlendMode (Renderer r) = makeStateVar getRenderDrawBlendMode setRenderDrawBlendMode
   where
@@ -521,7 +521,7 @@ rendererDrawBlendMode (Renderer r) = makeStateVar getRenderDrawBlendMode setRend
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetRenderDrawColor SDL_SetRenderDrawColor>@ and @<https://wiki.libsdl.org/SDL_GetRenderDrawColor SDL_GetRenderDrawColor>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetRenderDrawColor SDL_SetRenderDrawColor>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetRenderDrawColor SDL_GetRenderDrawColor>@ for C documentation.
 rendererDrawColor :: Renderer -> StateVar (V4 Word8)
 rendererDrawColor (Renderer re) = makeStateVar getRenderDrawColor setRenderDrawColor
   where
@@ -542,7 +542,7 @@ rendererDrawColor (Renderer re) = makeStateVar getRenderDrawColor setRenderDrawC
 --
 -- This is the function you use to reflect any changes to the surface on the screen.
 --
--- See @<https://wiki.libsdl.org/SDL_UpdateWindowSurface SDL_UpdateWindowSurface>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_UpdateWindowSurface SDL_UpdateWindowSurface>@ for C documentation.
 updateWindowSurface :: (Functor m, MonadIO m) => Window -> m ()
 updateWindowSurface (Window w) =
   throwIfNeg_ "SDL.Video.updateWindowSurface" "SDL_UpdateWindowSurface" $
@@ -617,7 +617,7 @@ newtype Texture = Texture Raw.Texture
 
 -- | Draw a rectangle outline on the current rendering target.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderDrawRect SDL_RenderDrawRect>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderDrawRect SDL_RenderDrawRect>@ for C documentation.
 drawRect :: MonadIO m
          => Renderer
          -> Maybe (Rectangle CInt) -- ^ The rectangle outline to draw. 'Nothing' for the entire rendering context.
@@ -628,7 +628,7 @@ drawRect (Renderer r) rect = liftIO $
 
 -- | Draw some number of rectangles on the current rendering target.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderDrawRects SDL_RenderDrawRects>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderDrawRects SDL_RenderDrawRects>@ for C documentation.
 drawRects :: MonadIO m => Renderer -> SV.Vector (Rectangle CInt) -> m ()
 drawRects (Renderer r) rects = liftIO $
   throwIfNeg_ "SDL.Video.drawRects" "SDL_RenderDrawRects" $
@@ -639,7 +639,7 @@ drawRects (Renderer r) rects = liftIO $
 
 -- | Fill a rectangle on the current rendering target with the drawing color.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderFillRect SDL_RenderFillRect>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderFillRect SDL_RenderFillRect>@ for C documentation.
 fillRect ::
      MonadIO m
   => Renderer
@@ -655,7 +655,7 @@ fillRect (Renderer r) rect =
 
 -- | Fill some number of rectangles on the current rendering target with the drawing color.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderFillRects SDL_RenderFillRects>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderFillRects SDL_RenderFillRects>@ for C documentation.
 fillRects :: MonadIO m => Renderer -> SV.Vector (Rectangle CInt) -> m ()
 fillRects (Renderer r) rects = liftIO $
   throwIfNeg_ "SDL.Video.fillRects" "SDL_RenderFillRects" $
@@ -793,7 +793,7 @@ renderGeometryRaw (Renderer r) mtexture xy xyStride color colorStride uv uvStrid
 
 -- | Clear the current rendering target with the drawing color.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderClear SDL_RenderClear>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderClear SDL_RenderClear>@ for C documentation.
 clear :: (Functor m, MonadIO m) => Renderer -> m ()
 clear (Renderer r) =
   throwIfNeg_ "SDL.Video.clear" "SDL_RenderClear" $
@@ -806,7 +806,7 @@ clear (Renderer r) =
 --
 -- If this results in scaling or subpixel drawing by the rendering backend, it will be handled using the appropriate quality hints. For best results use integer scaling factors.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderSetScale SDL_RenderSetScale>@ and @<https://wiki.libsdl.org/SDL_RenderGetScale SDL_RenderGetScale>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderSetScale SDL_RenderSetScale>@ and @<https://wiki.libsdl.org/SDL2/SDL_RenderGetScale SDL_RenderGetScale>@ for C documentation.
 rendererScale :: Renderer -> StateVar (V2 CFloat)
 rendererScale (Renderer r) = makeStateVar renderGetScale renderSetScale
   where
@@ -824,7 +824,7 @@ rendererScale (Renderer r) = makeStateVar renderGetScale renderSetScale
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderSetClipRect SDL_RenderSetClipRect>@ and @<https://wiki.libsdl.org/SDL_RenderGetClipRect SDL_RenderGetClipRect>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderSetClipRect SDL_RenderSetClipRect>@ and @<https://wiki.libsdl.org/SDL2/SDL_RenderGetClipRect SDL_RenderGetClipRect>@ for C documentation.
 rendererClipRect :: Renderer -> StateVar (Maybe (Rectangle CInt))
 rendererClipRect (Renderer r) = makeStateVar renderGetClipRect renderSetClipRect
   where
@@ -840,7 +840,7 @@ rendererClipRect (Renderer r) = makeStateVar renderGetClipRect renderSetClipRect
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderSetViewport SDL_RenderSetViewport>@ and @<https://wiki.libsdl.org/SDL_RenderGetViewport SDL_RenderGetViewport>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderSetViewport SDL_RenderSetViewport>@ and @<https://wiki.libsdl.org/SDL2/SDL_RenderGetViewport SDL_RenderGetViewport>@ for C documentation.
 rendererViewport :: Renderer -> StateVar (Maybe (Rectangle CInt))
 rendererViewport (Renderer r) = makeStateVar renderGetViewport renderSetViewport
   where
@@ -861,13 +861,13 @@ rendererViewport (Renderer r) = makeStateVar renderGetViewport renderSetViewport
 --
 -- The backbuffer should be considered invalidated after each present; do not assume that previous contents will exist between frames. You are strongly encouraged to call 'clear' to initialize the backbuffer before starting each new frame's drawing, even if you plan to overwrite every pixel.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderPresent SDL_RenderPresent>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderPresent SDL_RenderPresent>@ for C documentation.
 present :: MonadIO m => Renderer -> m ()
 present (Renderer r) = Raw.renderPresent r
 
 -- | Copy a portion of the texture to the current rendering target.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderCopy SDL_RenderCopy>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderCopy SDL_RenderCopy>@ for C documentation.
 copy :: MonadIO m
      => Renderer -- ^ The rendering context
      -> Texture -- ^ The source texture
@@ -883,7 +883,7 @@ copy (Renderer r) (Texture t) srcRect dstRect =
 
 -- | Copy a portion of the texture to the current rendering target, optionally rotating it by angle around the given center and also flipping it top-bottom and/or left-right.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderCopyEx SDL_RenderCopyEx>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderCopyEx SDL_RenderCopyEx>@ for C documentation.
 copyEx :: MonadIO m
        => Renderer -- ^ The rendering context
        -> Texture -- ^ The source texture
@@ -906,7 +906,7 @@ copyEx (Renderer r) (Texture t) srcRect dstRect theta center flips =
 
 -- | Draw a line on the current rendering target.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderDrawLine SDL_RenderDrawLine>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderDrawLine SDL_RenderDrawLine>@ for C documentation.
 drawLine :: (Functor m,MonadIO m)
          => Renderer
          -> Point V2 CInt -- ^ The start point of the line
@@ -918,7 +918,7 @@ drawLine (Renderer r) (P (V2 x y)) (P (V2 x' y')) =
 
 -- | Draw a series of connected lines on the current rendering target.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderDrawLines SDL_RenderDrawLines>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderDrawLines SDL_RenderDrawLines>@ for C documentation.
 drawLines :: MonadIO m
           => Renderer
           -> SV.Vector (Point V2 CInt) -- ^ A 'SV.Vector' of points along the line. SDL will draw lines between these points.
@@ -933,7 +933,7 @@ drawLines (Renderer r) points =
 
 -- | Draw a point on the current rendering target.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderDrawPoint SDL_RenderDrawPoint>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderDrawPoint SDL_RenderDrawPoint>@ for C documentation.
 drawPoint :: (Functor m, MonadIO m) => Renderer -> Point V2 CInt -> m ()
 drawPoint (Renderer r) (P (V2 x y)) =
   throwIfNeg_ "SDL.Video.drawPoint" "SDL_RenderDrawPoint" $
@@ -941,7 +941,7 @@ drawPoint (Renderer r) (P (V2 x y)) =
 
 -- | Draw multiple points on the current rendering target.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderDrawPoints SDL_RenderDrawPoints>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderDrawPoints SDL_RenderDrawPoints>@ for C documentation.
 drawPoints :: MonadIO m => Renderer -> SV.Vector (Point V2 CInt) -> m ()
 drawPoints (Renderer r) points =
   liftIO $
@@ -955,7 +955,7 @@ drawPoints (Renderer r) points =
 --
 -- This function is used to optimize images for faster repeat blitting. This is accomplished by converting the original and storing the result as a new surface. The new, optimized surface can then be used as the source for future blits, making them faster.
 --
--- See @<https://wiki.libsdl.org/SDL_ConvertSurface SDL_ConvertSurface>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_ConvertSurface SDL_ConvertSurface>@ for C documentation.
 convertSurface :: (Functor m,MonadIO m)
                => Surface -- ^ The 'Surface' to convert
                -> SurfacePixelFormat -- ^ The pixel format that the new surface is optimized for
@@ -967,7 +967,7 @@ convertSurface (Surface s _) (SurfacePixelFormat fmt) =
 
 -- | Perform a scaled surface copy to a destination surface.
 --
--- See @<https://wiki.libsdl.org/SDL_BlitScaled SDL_BlitScaled>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_BlitScaled SDL_BlitScaled>@ for C documentation.
 surfaceBlitScaled :: MonadIO m
                   => Surface -- ^ The 'Surface' to be copied from
                   -> Maybe (Rectangle CInt) -- ^ The rectangle to be copied, or 'Nothing' to copy the entire surface
@@ -985,7 +985,7 @@ surfaceBlitScaled (Surface src _) srcRect (Surface dst _) dstRect =
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetColorKey SDL_SetColorKey>@ and @<https://wiki.libsdl.org/SDL_GetColorKey SDL_GetColorKey>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetColorKey SDL_SetColorKey>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetColorKey SDL_GetColorKey>@ for C documentation.
 surfaceColorKey :: Surface -> StateVar (Maybe (V4 Word8))
 surfaceColorKey (Surface s _) = makeStateVar getColorKey setColorKey
   where
@@ -1024,7 +1024,7 @@ surfaceColorKey (Surface s _) = makeStateVar getColorKey setColorKey
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetTextureColorMod SDL_SetTextureColorMod>@ and @<https://wiki.libsdl.org/SDL_GetTextureColorMod SDL_GetTextureColorMod>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetTextureColorMod SDL_SetTextureColorMod>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetTextureColorMod SDL_GetTextureColorMod>@ for C documentation.
 textureColorMod :: Texture -> StateVar (V3 Word8)
 textureColorMod (Texture t) = makeStateVar getTextureColorMod setTextureColorMod
   where
@@ -1239,7 +1239,7 @@ fromRawRendererInfo (Raw.RendererInfo name flgs ntf tfs mtw mth) = liftIO $ do
 
 -- | Get information about a rendering context.
 --
--- See @<https://wiki.libsdl.org/SDL_GetRendererInfo SDL_GetRendererInfo>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetRendererInfo SDL_GetRendererInfo>@ for C documentation.
 getRendererInfo :: MonadIO m => Renderer -> m RendererInfo
 getRendererInfo (Renderer renderer) = liftIO $
   alloca $ \rptr -> do
@@ -1249,7 +1249,7 @@ getRendererInfo (Renderer renderer) = liftIO $
 
 -- | Enumerate all known render drivers on the system, and determine their supported features.
 --
--- See @<https://wiki.libsdl.org/SDL_GetRenderDriverInfo SDL_GetRenderDriverInfo>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_GetRenderDriverInfo SDL_GetRenderDriverInfo>@ for C documentation.
 getRenderDriverInfo :: MonadIO m => m [RendererInfo]
 getRenderDriverInfo = liftIO $ do
   count <- Raw.getNumRenderDrivers
@@ -1264,7 +1264,7 @@ getRenderDriverInfo = liftIO $ do
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetTextureAlphaMod SDL_SetTextureAlphaMod>@ and @<https://wiki.libsdl.org/SDL_GetTextureAlphaMod SDL_GetTextureAlphaMod>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetTextureAlphaMod SDL_SetTextureAlphaMod>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetTextureAlphaMod SDL_GetTextureAlphaMod>@ for C documentation.
 textureAlphaMod :: Texture -> StateVar Word8
 textureAlphaMod (Texture t) = makeStateVar getTextureAlphaMod setTextureAlphaMod
   where
@@ -1282,7 +1282,7 @@ textureAlphaMod (Texture t) = makeStateVar getTextureAlphaMod setTextureAlphaMod
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetTextureBlendMode SDL_SetTextureBlendMode>@ and @<https://wiki.libsdl.org/SDL_GetTextureBlendMode SDL_GetTextureBlendMode>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetTextureBlendMode SDL_SetTextureBlendMode>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetTextureBlendMode SDL_GetTextureBlendMode>@ for C documentation.
 textureBlendMode :: Texture -> StateVar BlendMode
 textureBlendMode (Texture t) = makeStateVar getTextureBlendMode setTextureBlendMode
   where
@@ -1300,7 +1300,7 @@ textureBlendMode (Texture t) = makeStateVar getTextureBlendMode setTextureBlendM
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetSurfaceBlendMode SDL_SetSurfaceBlendMode>@ and @<https://wiki.libsdl.org/SDL_GetSurfaceBlendMode SDL_GetSurfaceBlendMode>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetSurfaceBlendMode SDL_SetSurfaceBlendMode>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetSurfaceBlendMode SDL_GetSurfaceBlendMode>@ for C documentation.
 surfaceBlendMode :: Surface -> StateVar BlendMode
 surfaceBlendMode (Surface s _) = makeStateVar getSurfaceBlendMode setSurfaceBlendMode
   where
@@ -1318,7 +1318,7 @@ surfaceBlendMode (Surface s _) = makeStateVar getSurfaceBlendMode setSurfaceBlen
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_SetRenderTarget SDL_SetRenderTarget>@ and @<https://wiki.libsdl.org/SDL_GetRenderTarget SDL_GetRenderTarget>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_SetRenderTarget SDL_SetRenderTarget>@ and @<https://wiki.libsdl.org/SDL2/SDL_GetRenderTarget SDL_GetRenderTarget>@ for C documentation.
 rendererRenderTarget :: Renderer -> StateVar (Maybe Texture)
 rendererRenderTarget (Renderer r) = makeStateVar getRenderTarget setRenderTarget
   where
@@ -1341,7 +1341,7 @@ rendererRenderTarget (Renderer r) = makeStateVar getRenderTarget setRenderTarget
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderSetIntegerScale SDL_RenderSetIntegerScale>@ and @<https://wiki.libsdl.org/SDL_RenderGetIntegerScale SDL_RenderGetIntegerScale>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderSetIntegerScale SDL_RenderSetIntegerScale>@ and @<https://wiki.libsdl.org/SDL2/SDL_RenderGetIntegerScale SDL_RenderGetIntegerScale>@ for C documentation.
 rendererIntegerScale :: Renderer -> StateVar Bool
 rendererIntegerScale (Renderer r) = makeStateVar renderGetIntegerScale renderSetIntegerScale
   where
@@ -1356,7 +1356,7 @@ rendererIntegerScale (Renderer r) = makeStateVar renderGetIntegerScale renderSet
 --
 -- This 'StateVar' can be modified using '$=' and the current value retrieved with 'get'.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderSetLogicalSize SDL_RenderSetLogicalSize>@ and @<https://wiki.libsdl.org/SDL_RenderGetLogicalSize SDL_RenderGetLogicalSize>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderSetLogicalSize SDL_RenderSetLogicalSize>@ and @<https://wiki.libsdl.org/SDL2/SDL_RenderGetLogicalSize SDL_RenderGetLogicalSize>@ for C documentation.
 rendererLogicalSize :: Renderer -> StateVar (Maybe (V2 CInt))
 rendererLogicalSize (Renderer r) = makeStateVar renderGetLogicalSize renderSetLogicalSize
   where
@@ -1375,13 +1375,13 @@ rendererLogicalSize (Renderer r) = makeStateVar renderGetLogicalSize renderSetLo
 
 -- | Determine whether a window supports the use of render targets.
 --
--- See @<https://wiki.libsdl.org/SDL_RenderTargetSupported SDL_RenderTargetSupported>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_RenderTargetSupported SDL_RenderTargetSupported>@ for C documentation.
 renderTargetSupported :: (MonadIO m) => Renderer -> m Bool
 renderTargetSupported (Renderer r) = Raw.renderTargetSupported r
 
 -- | Convert the given the enumerated pixel format to a bpp value and RGBA masks.
 --
--- See @<https://wiki.libsdl.org/SDL_PixelFormatEnumToMasks SDL_PixelFormatEnumToMasks>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_PixelFormatEnumToMasks SDL_PixelFormatEnumToMasks>@ for C documentation.
 pixelFormatToMasks :: (MonadIO m) => PixelFormat -> m (CInt, V4 Word32)
 pixelFormatToMasks pf = liftIO $
   alloca $ \bpp ->
@@ -1397,7 +1397,7 @@ pixelFormatToMasks pf = liftIO $
 
 -- | Convert a bpp value and RGBA masks to an enumerated pixel format.
 --
--- See @<https://wiki.libsdl.org/SDL_MasksToPixelFormatEnum SDL_MasksToPixelFormatEnum>@ for C documentation.
+-- See @<https://wiki.libsdl.org/SDL2/SDL_MasksToPixelFormatEnum SDL_MasksToPixelFormatEnum>@ for C documentation.
 masksToPixelFormat :: (MonadIO m) => CInt -> V4 Word32 -> m PixelFormat
 masksToPixelFormat bpp (V4 r g b a) = liftIO $
   fromNumber <$> Raw.masksToPixelFormatEnum bpp r g b a


### PR DESCRIPTION
They restructured their URLs upstream, prefixing with `/SDL2` or `/SDL3`, and the old URLs redirect to SDL3 now, subtly breaking the library documentation here.

Example:
- old: https://wiki.libsdl.org/SDL_OpenAudioDevice
- new: https://wiki.libsdl.org/SDL2/SDL_OpenAudioDevice